### PR TITLE
feat(dictyon): Noise IK handshake, key types, HTTP transport skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Crypto primitives (placeholder — actual WireGuard uses boringtun)
 # boringtun = "0.6"  # uncomment when dictyon data plane begins
 
+# Noise protocol
+snow = "0.10"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+zeroize = { version = "1", features = ["derive"] }
+rand = "0.8"
+base64 = "0.22"
+
 # Testing
 proptest = "1"
 

--- a/crates/dictyon/Cargo.toml
+++ b/crates/dictyon/Cargo.toml
@@ -17,6 +17,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+snow = { workspace = true }
+zeroize = { workspace = true }
+base64 = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/dictyon/src/lib.rs
+++ b/crates/dictyon/src/lib.rs
@@ -10,8 +10,8 @@
 //!
 //! ## Status
 //!
-//! Pre-alpha scaffold. Nothing here works yet. See the project roadmap in
-//! kanon/projects/plegma for the phase plan.
+//! Noise IK handshake and key types implemented. HTTP transport skeleton
+//! in place. No actual TCP I/O yet.
 //!
 //! ## Scope
 //!
@@ -27,20 +27,5 @@
 
 #![deny(missing_docs)]
 
-/// Placeholder sentinel indicating the crate is reachable from the workspace.
-///
-/// Removed when the first real module lands.
-#[must_use]
-pub const fn scaffold_sentinel() -> &'static str {
-    "dictyon"
-}
-
-#[cfg(test)]
-mod tests {
-    use super::scaffold_sentinel;
-
-    #[test]
-    fn sentinel_returns_crate_name() {
-        assert_eq!(scaffold_sentinel(), "dictyon");
-    }
-}
+pub mod noise;
+pub mod transport;

--- a/crates/dictyon/src/noise.rs
+++ b/crates/dictyon/src/noise.rs
@@ -1,0 +1,516 @@
+//! Noise IK handshake for the Tailscale control protocol.
+//!
+//! Implements `Noise_IK_25519_ChaChaPoly_BLAKE2s` using the `snow` crate.
+//! The IK pattern means the client (initiator) knows the server's static
+//! public key in advance (fetched via `/key?v=N`). The client's static key
+//! (machine key) is encrypted and sent to the server during the handshake.
+//!
+//! # Protocol framing
+//!
+//! - Initiation message: `[2B version][1B type=0x01][2B payload_len][noise_msg]`
+//! - Response message: `[1B type=0x02][2B payload_len][noise_msg]`
+//! - Post-handshake transport frames: `[1B type=0x04][2B BE length][ciphertext]`
+//!
+//! See `control/controlbase/` in the Tailscale Go source for reference.
+
+use plegma_core::keys::{MachinePrivate, MachinePublic};
+use snafu::Snafu;
+use snow::{Builder, HandshakeState, TransportState};
+
+/// Noise protocol parameters for the Tailscale control plane.
+const NOISE_PARAMS: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
+
+/// Current protocol version for the Noise handshake.
+const PROTOCOL_VERSION: u16 = 1;
+
+/// Message type for the initiator's first message.
+const MSG_TYPE_INITIATION: u8 = 0x01;
+
+/// Message type for the responder's reply.
+const MSG_TYPE_RESPONSE: u8 = 0x02;
+
+/// Message type for post-handshake transport frames.
+const MSG_TYPE_TRANSPORT: u8 = 0x04;
+
+/// Maximum Noise transport frame payload size (before encryption).
+const MAX_FRAME_PAYLOAD: usize = 4096;
+
+/// Poly1305 tag length added by AEAD encryption.
+const TAG_LEN: usize = 16;
+
+/// Prologue mixed into the handshake hash, binding the session to the
+/// Tailscale control protocol and its version.
+fn prologue() -> Vec<u8> {
+    format!("Tailscale Control Protocol v{PROTOCOL_VERSION}").into_bytes()
+}
+
+/// Errors that can occur during the Noise handshake or transport.
+#[derive(Debug, Snafu)]
+pub enum NoiseError {
+    /// The Noise handshake failed.
+    #[snafu(display("noise handshake failed: {message}"))]
+    HandshakeFailed {
+        /// Description of the failure.
+        message: String,
+    },
+
+    /// Decryption of a transport message failed.
+    #[snafu(display("decryption failed: {message}"))]
+    DecryptionFailed {
+        /// Description of the failure.
+        message: String,
+    },
+
+    /// Operation attempted in an invalid state (e.g., encrypting before
+    /// the handshake is complete).
+    #[snafu(display("invalid state: {message}"))]
+    InvalidState {
+        /// Description of the invalid state.
+        message: String,
+    },
+
+    /// An error from the underlying `snow` library.
+    #[snafu(display("snow error: {source}"))]
+    Snow {
+        /// The underlying snow error.
+        source: snow::Error,
+    },
+}
+
+impl From<snow::Error> for NoiseError {
+    fn from(source: snow::Error) -> Self {
+        Self::Snow { source }
+    }
+}
+
+/// Drives the Noise IK handshake from the client (initiator) side.
+///
+/// Usage:
+/// 1. Create with [`NoiseHandshake::new`].
+/// 2. Call [`initiation_message`](NoiseHandshake::initiation_message) to get
+///    the bytes for the `X-Tailscale-Handshake` header.
+/// 3. Send the HTTP upgrade request.
+/// 4. Call [`process_response`](NoiseHandshake::process_response) with the
+///    server's response to complete the handshake.
+pub struct NoiseHandshake {
+    state: HandshakePhase,
+}
+
+/// Internal state machine for the handshake.
+enum HandshakePhase {
+    /// Ready to generate the initiation message.
+    Ready {
+        machine_key: MachinePrivate,
+        server_public: MachinePublic,
+    },
+    /// Initiation sent, waiting for the response.
+    AwaitingResponse { handshake: Box<HandshakeState> },
+    /// Handshake consumed (moved into transport).
+    Completed,
+}
+
+impl NoiseHandshake {
+    /// Create a new handshake initiator.
+    ///
+    /// # Arguments
+    ///
+    /// * `machine_key` - The client's machine identity key.
+    /// * `server_public` - The server's static public key (from `/key?v=N`).
+    pub fn new(machine_key: MachinePrivate, server_public: MachinePublic) -> Self {
+        Self {
+            state: HandshakePhase::Ready {
+                machine_key,
+                server_public,
+            },
+        }
+    }
+
+    /// Generate the initiator message (Noise IK pattern, message 1).
+    ///
+    /// Returns the framed initiation message bytes suitable for base64
+    /// encoding into the `X-Tailscale-Handshake` header value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NoiseError::InvalidState`] if called more than once, or
+    /// [`NoiseError::Snow`] if the snow library fails.
+    pub fn initiation_message(&mut self) -> Result<Vec<u8>, NoiseError> {
+        let (machine_key, server_public) =
+            match core::mem::replace(&mut self.state, HandshakePhase::Completed) {
+                HandshakePhase::Ready {
+                    machine_key,
+                    server_public,
+                } => (machine_key, server_public),
+                HandshakePhase::AwaitingResponse { .. } | HandshakePhase::Completed => {
+                    return Err(NoiseError::InvalidState {
+                        message: "initiation already generated".into(),
+                    });
+                }
+            };
+
+        let params = NOISE_PARAMS.parse().map_err(NoiseError::from)?;
+        let prologue = prologue();
+
+        let mut handshake = Builder::new(params)
+            .local_private_key(machine_key.as_bytes())?
+            .remote_public_key(server_public.as_bytes())?
+            .prologue(&prologue)?
+            .build_initiator()?;
+
+        // IK message 1: e, es, s, ss
+        // snow needs a buffer large enough for the handshake message.
+        // IK msg1 = 32 (ephemeral pub) + 32 (static pub encrypted) + 16 (tag) + 16 (empty payload tag) = 96
+        let mut noise_msg = vec![0u8; 256];
+        let noise_len = handshake.write_message(&[], &mut noise_msg)?;
+        noise_msg.truncate(noise_len);
+
+        // Frame: [2B version LE][1B msg_type][2B payload_len BE][noise_msg]
+        let payload_len = u16::try_from(noise_len).map_err(|_| NoiseError::HandshakeFailed {
+            message: "initiation message too large".into(),
+        })?;
+
+        let mut framed = Vec::with_capacity(5 + noise_len);
+        framed.extend_from_slice(&PROTOCOL_VERSION.to_le_bytes());
+        framed.push(MSG_TYPE_INITIATION);
+        framed.extend_from_slice(&payload_len.to_be_bytes());
+        framed.extend_from_slice(&noise_msg);
+
+        self.state = HandshakePhase::AwaitingResponse {
+            handshake: Box::new(handshake),
+        };
+
+        Ok(framed)
+    }
+
+    /// Process the responder message (Noise IK pattern, message 2) and
+    /// complete the handshake.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NoiseError::InvalidState`] if called before
+    /// [`initiation_message`](NoiseHandshake::initiation_message), or
+    /// [`NoiseError::Snow`] / [`NoiseError::HandshakeFailed`] if the
+    /// response is invalid.
+    pub fn process_response(mut self, response: &[u8]) -> Result<NoiseTransport, NoiseError> {
+        let mut handshake = match core::mem::replace(&mut self.state, HandshakePhase::Completed) {
+            HandshakePhase::AwaitingResponse { handshake } => *handshake,
+            HandshakePhase::Ready { .. } => {
+                return Err(NoiseError::InvalidState {
+                    message: "initiation not yet sent".into(),
+                });
+            }
+            HandshakePhase::Completed => {
+                return Err(NoiseError::InvalidState {
+                    message: "handshake already completed".into(),
+                });
+            }
+        };
+
+        // Parse framed response: [1B msg_type][2B payload_len BE][noise_msg]
+        if response.len() < 3 {
+            return Err(NoiseError::HandshakeFailed {
+                message: "response too short".into(),
+            });
+        }
+
+        let msg_type = response[0];
+        if msg_type != MSG_TYPE_RESPONSE {
+            return Err(NoiseError::HandshakeFailed {
+                message: format!("unexpected message type: 0x{msg_type:02x}"),
+            });
+        }
+
+        let payload_len = u16::from_be_bytes([response[1], response[2]]) as usize;
+        let noise_msg =
+            response
+                .get(3..3 + payload_len)
+                .ok_or_else(|| NoiseError::HandshakeFailed {
+                    message: "response payload truncated".into(),
+                })?;
+
+        // IK message 2: e, ee, se
+        let mut payload_buf = vec![0u8; 256];
+        let _payload_len = handshake.read_message(noise_msg, &mut payload_buf)?;
+
+        let transport = handshake.into_transport_mode()?;
+
+        Ok(NoiseTransport { transport })
+    }
+}
+
+/// Established Noise transport -- encrypts/decrypts control protocol messages.
+///
+/// Created after a successful [`NoiseHandshake`]. All messages are framed as
+/// `[1B type=0x04][2B BE length][ciphertext]`.
+pub struct NoiseTransport {
+    transport: TransportState,
+}
+
+impl NoiseTransport {
+    /// Encrypt a plaintext message for sending to the server.
+    ///
+    /// Returns the Noise transport frame: `[1B type][2B BE len][ciphertext]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NoiseError::HandshakeFailed`] if the plaintext exceeds
+    /// the maximum frame payload size, or [`NoiseError::Snow`] on
+    /// encryption failure.
+    pub fn encrypt(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, NoiseError> {
+        if plaintext.len() > MAX_FRAME_PAYLOAD {
+            return Err(NoiseError::HandshakeFailed {
+                message: format!(
+                    "payload too large: {} > {MAX_FRAME_PAYLOAD}",
+                    plaintext.len()
+                ),
+            });
+        }
+
+        let mut ciphertext = vec![0u8; plaintext.len() + TAG_LEN];
+        let ct_len = self.transport.write_message(plaintext, &mut ciphertext)?;
+        ciphertext.truncate(ct_len);
+
+        let frame_len = u16::try_from(ct_len).map_err(|_| NoiseError::HandshakeFailed {
+            message: "ciphertext too large for frame".into(),
+        })?;
+
+        let mut frame = Vec::with_capacity(3 + ct_len);
+        frame.push(MSG_TYPE_TRANSPORT);
+        frame.extend_from_slice(&frame_len.to_be_bytes());
+        frame.extend_from_slice(&ciphertext);
+
+        Ok(frame)
+    }
+
+    /// Decrypt a ciphertext message received from the server.
+    ///
+    /// Expects raw ciphertext bytes (without the frame header -- the caller
+    /// is responsible for stripping the `[1B type][2B len]` prefix).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NoiseError::DecryptionFailed`] or [`NoiseError::Snow`]
+    /// if decryption fails.
+    pub fn decrypt(&mut self, ciphertext: &[u8]) -> Result<Vec<u8>, NoiseError> {
+        if ciphertext.len() < TAG_LEN {
+            return Err(NoiseError::DecryptionFailed {
+                message: "ciphertext too short for authentication tag".into(),
+            });
+        }
+
+        let mut plaintext = vec![0u8; ciphertext.len()];
+        let pt_len = self
+            .transport
+            .read_message(ciphertext, &mut plaintext)
+            .map_err(|e| NoiseError::DecryptionFailed {
+                message: format!("{e}"),
+            })?;
+        plaintext.truncate(pt_len);
+
+        Ok(plaintext)
+    }
+
+    /// Create a `NoiseTransport` directly from a `snow::TransportState`.
+    ///
+    /// This is exposed for testing -- production code should go through
+    /// [`NoiseHandshake`].
+    #[cfg(test)]
+    pub(crate) fn from_snow(transport: TransportState) -> Self {
+        Self { transport }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a snow responder for testing against our initiator.
+    fn build_responder(server_private: &[u8; 32]) -> Result<HandshakeState, NoiseError> {
+        let params = NOISE_PARAMS.parse().map_err(NoiseError::from)?;
+        let prologue = prologue();
+        let responder = Builder::new(params)
+            .local_private_key(server_private)?
+            .prologue(&prologue)?
+            .build_responder()?;
+        Ok(responder)
+    }
+
+    #[test]
+    fn handshake_initiation_produces_message() {
+        let machine_key = MachinePrivate::generate();
+        let server_key = MachinePrivate::generate();
+        let server_pub = server_key.public_key();
+
+        let mut handshake = NoiseHandshake::new(machine_key, server_pub);
+        let msg = handshake
+            .initiation_message()
+            .expect("initiation should succeed");
+
+        // Framed message: 2B version + 1B type + 2B length + noise payload
+        assert!(msg.len() > 5, "message should contain header + payload");
+
+        // Check version (LE u16)
+        assert_eq!(msg[0], 0x01); // version 1 low byte
+        assert_eq!(msg[1], 0x00); // version 1 high byte
+
+        // Check message type
+        assert_eq!(msg[2], MSG_TYPE_INITIATION);
+    }
+
+    #[test]
+    fn noise_ik_handshake_completes() {
+        let machine_key = MachinePrivate::generate();
+        let server_key = MachinePrivate::generate();
+        let server_pub = server_key.public_key();
+
+        // --- Initiator side ---
+        let mut handshake = NoiseHandshake::new(machine_key, server_pub);
+        let init_msg = handshake
+            .initiation_message()
+            .expect("initiation should succeed");
+
+        // --- Responder side (simulated server) ---
+        let mut responder =
+            build_responder(server_key.as_bytes()).expect("responder build should succeed");
+
+        // Strip our framing to get raw noise message
+        let payload_len = u16::from_be_bytes([init_msg[3], init_msg[4]]) as usize;
+        let noise_init = &init_msg[5..5 + payload_len];
+
+        let mut payload_buf = vec![0u8; 256];
+        let _pt_len = responder
+            .read_message(noise_init, &mut payload_buf)
+            .expect("responder should read msg1");
+
+        // Responder writes msg2
+        let mut resp_noise = vec![0u8; 256];
+        let resp_noise_len = responder
+            .write_message(&[], &mut resp_noise)
+            .expect("responder should write msg2");
+
+        // Frame the response: [1B type][2B BE len][noise_msg]
+        let mut framed_resp = Vec::new();
+        framed_resp.push(MSG_TYPE_RESPONSE);
+        let len_be = u16::try_from(resp_noise_len)
+            .expect("response length fits u16")
+            .to_be_bytes();
+        framed_resp.extend_from_slice(&len_be);
+        framed_resp.extend_from_slice(&resp_noise[..resp_noise_len]);
+
+        // --- Complete handshake on initiator ---
+        let _transport = handshake
+            .process_response(&framed_resp)
+            .expect("handshake completion should succeed");
+    }
+
+    #[test]
+    fn transport_encrypt_decrypt_round_trips() {
+        // Do a full handshake to get paired transport states.
+        let (mut client_transport, mut server_transport) = paired_transports();
+
+        let plaintext = b"hello from the dictyon client";
+        let frame = client_transport
+            .encrypt(plaintext)
+            .expect("encrypt should succeed");
+
+        // Verify it's framed
+        assert_eq!(frame[0], MSG_TYPE_TRANSPORT);
+
+        // Strip frame header for decryption
+        let ct_len = u16::from_be_bytes([frame[1], frame[2]]) as usize;
+        let ciphertext = &frame[3..3 + ct_len];
+
+        let decrypted = server_transport
+            .decrypt(ciphertext)
+            .expect("decrypt should succeed");
+        assert_eq!(&decrypted, plaintext);
+    }
+
+    #[test]
+    fn decrypt_wrong_key_fails() {
+        let (mut client_transport, _server_transport) = paired_transports();
+
+        let plaintext = b"secret message";
+        let frame = client_transport
+            .encrypt(plaintext)
+            .expect("encrypt should succeed");
+
+        // Strip frame header
+        let ct_len = u16::from_be_bytes([frame[1], frame[2]]) as usize;
+        let ciphertext = &frame[3..3 + ct_len];
+
+        // Build a completely different transport (wrong keys)
+        let (_other_client, mut other_server) = paired_transports();
+
+        let result = other_server.decrypt(ciphertext);
+        assert!(result.is_err(), "decrypting with wrong key should fail");
+    }
+
+    /// Helper: perform a full handshake and return paired transport states.
+    fn paired_transports() -> (NoiseTransport, NoiseTransport) {
+        let machine_key = MachinePrivate::generate();
+        let server_key = MachinePrivate::generate();
+        let server_pub = server_key.public_key();
+
+        // Initiator
+        let params = NOISE_PARAMS
+            .parse::<snow::params::NoiseParams>()
+            .expect("params should parse");
+        let prologue_bytes = prologue();
+
+        let mut initiator = Builder::new(params)
+            .local_private_key(machine_key.as_bytes())
+            .expect("local_private_key should succeed")
+            .remote_public_key(server_pub.as_bytes())
+            .expect("remote_public_key should succeed")
+            .prologue(&prologue_bytes)
+            .expect("prologue should succeed")
+            .build_initiator()
+            .expect("build_initiator should succeed");
+
+        // Responder
+        let params2 = NOISE_PARAMS
+            .parse::<snow::params::NoiseParams>()
+            .expect("params should parse");
+        let mut responder = Builder::new(params2)
+            .local_private_key(server_key.as_bytes())
+            .expect("local_private_key should succeed")
+            .prologue(&prologue_bytes)
+            .expect("prologue should succeed")
+            .build_responder()
+            .expect("build_responder should succeed");
+
+        let mut buf = vec![0u8; 65535];
+        let mut payload = vec![0u8; 65535];
+
+        // msg1: initiator -> responder
+        let len = initiator.write_message(&[], &mut buf).expect("write msg1");
+        responder
+            .read_message(&buf[..len], &mut payload)
+            .expect("read msg1");
+
+        // msg2: responder -> initiator
+        let len = responder.write_message(&[], &mut buf).expect("write msg2");
+        initiator
+            .read_message(&buf[..len], &mut payload)
+            .expect("read msg2");
+
+        let client = NoiseTransport::from_snow(
+            initiator
+                .into_transport_mode()
+                .expect("initiator transport"),
+        );
+        let server = NoiseTransport::from_snow(
+            responder
+                .into_transport_mode()
+                .expect("responder transport"),
+        );
+
+        (client, server)
+    }
+}

--- a/crates/dictyon/src/transport.rs
+++ b/crates/dictyon/src/transport.rs
@@ -1,0 +1,313 @@
+//! HTTP transport skeleton for the Tailscale control protocol.
+//!
+//! Implements the framing and encryption layer that wraps control plane
+//! messages. The actual TCP I/O is deferred to a future milestone -- this
+//! module provides the request construction, response parsing, and
+//! encrypt/decrypt plumbing.
+//!
+//! # Protocol flow
+//!
+//! 1. Client sends `POST /ts2021` with `Upgrade: tailscale-control-protocol`
+//!    and the Noise initiation in `X-Tailscale-Handshake` (base64).
+//! 2. Server responds `101 Switching Protocols`.
+//! 3. Client completes the Noise handshake.
+//! 4. All subsequent messages are Noise-encrypted frames:
+//!    `[1B type=0x04][2B BE length][ciphertext]`.
+
+use base64::Engine;
+
+use crate::noise::{NoiseError, NoiseHandshake, NoiseTransport};
+use snafu::Snafu;
+
+/// The HTTP upgrade path for the Tailscale Noise protocol.
+const UPGRADE_PATH: &str = "/ts2021";
+
+/// The HTTP `Upgrade` header value.
+const UPGRADE_HEADER_VALUE: &str = "tailscale-control-protocol";
+
+/// Errors specific to the control connection transport.
+#[derive(Debug, Snafu)]
+pub enum TransportError {
+    /// A Noise-layer error occurred.
+    #[snafu(display("noise error: {source}"))]
+    Noise {
+        /// The underlying Noise error.
+        source: NoiseError,
+    },
+
+    /// The control URL was invalid.
+    #[snafu(display("invalid control URL: {url}"))]
+    InvalidUrl {
+        /// The URL that failed validation.
+        url: String,
+    },
+}
+
+impl From<NoiseError> for TransportError {
+    fn from(source: NoiseError) -> Self {
+        Self::Noise { source }
+    }
+}
+
+/// An established control connection with Noise encryption.
+///
+/// This is currently a skeleton -- it holds the [`NoiseTransport`] and
+/// provides encrypt/decrypt operations, but does not own a TCP stream.
+/// Actual I/O will be added in a future milestone using tokio.
+pub struct ControlConnection {
+    noise: NoiseTransport,
+}
+
+/// A prepared HTTP upgrade request for the `/ts2021` endpoint.
+///
+/// Contains the URL and headers needed to initiate the Noise handshake
+/// over HTTP. The caller is responsible for sending this with an HTTP
+/// client.
+#[derive(Debug)]
+pub struct UpgradeRequest {
+    /// The full URL to POST to (e.g., `https://controlplane.tailscale.com/ts2021`).
+    pub url: String,
+    /// HTTP headers to include in the request.
+    pub headers: Vec<(String, String)>,
+}
+
+impl ControlConnection {
+    /// Build the HTTP upgrade request for `/ts2021`.
+    ///
+    /// Generates the Noise initiation message, base64-encodes it, and
+    /// returns the URL and headers to send with an HTTP client.
+    ///
+    /// # Arguments
+    ///
+    /// * `handshake` - A mutable reference to the [`NoiseHandshake`] that
+    ///   will generate the initiation message.
+    /// * `control_url` - The base URL of the control server (e.g.,
+    ///   `https://controlplane.tailscale.com`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransportError::Noise`] if the Noise initiation fails,
+    /// or [`TransportError::InvalidUrl`] if the control URL is empty.
+    pub fn build_upgrade_request(
+        handshake: &mut NoiseHandshake,
+        control_url: &str,
+    ) -> Result<UpgradeRequest, TransportError> {
+        if control_url.is_empty() {
+            return Err(TransportError::InvalidUrl {
+                url: control_url.to_string(),
+            });
+        }
+
+        let init_msg = handshake.initiation_message()?;
+
+        let init_b64 = base64::engine::general_purpose::STANDARD.encode(&init_msg);
+
+        let url = format!("{}{UPGRADE_PATH}", control_url.trim_end_matches('/'));
+
+        let headers = vec![
+            ("Upgrade".to_string(), UPGRADE_HEADER_VALUE.to_string()),
+            ("Connection".to_string(), "Upgrade".to_string()),
+            ("X-Tailscale-Handshake".to_string(), init_b64),
+        ];
+
+        Ok(UpgradeRequest { url, headers })
+    }
+
+    /// Process the HTTP 101 response and complete the Noise handshake.
+    ///
+    /// # Arguments
+    ///
+    /// * `handshake` - The [`NoiseHandshake`] used to build the upgrade
+    ///   request. Consumed to produce the transport.
+    /// * `response_body` - The raw bytes of the server's Noise response
+    ///   (from the HTTP 101 response body).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransportError::Noise`] if the handshake completion fails.
+    pub fn complete_handshake(
+        handshake: NoiseHandshake,
+        response_body: &[u8],
+    ) -> Result<Self, TransportError> {
+        let noise = handshake.process_response(response_body)?;
+        Ok(Self { noise })
+    }
+
+    /// Encrypt a control protocol message for sending to the server.
+    ///
+    /// Returns the Noise-framed ciphertext ready to write to the wire.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransportError::Noise`] if encryption fails.
+    pub fn send(&mut self, payload: &[u8]) -> Result<Vec<u8>, TransportError> {
+        let frame = self.noise.encrypt(payload)?;
+        Ok(frame)
+    }
+
+    /// Decrypt a control protocol message received from the server.
+    ///
+    /// Expects raw ciphertext bytes (without the frame header). The caller
+    /// is responsible for reading the `[1B type][2B len]` frame header and
+    /// extracting the ciphertext payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TransportError::Noise`] if decryption fails.
+    pub fn receive(&mut self, data: &[u8]) -> Result<Vec<u8>, TransportError> {
+        let plaintext = self.noise.decrypt(data)?;
+        Ok(plaintext)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use plegma_core::keys::MachinePrivate;
+
+    use super::*;
+
+    #[test]
+    fn build_upgrade_request_sets_correct_headers() {
+        let machine_key = MachinePrivate::generate();
+        let server_key = MachinePrivate::generate();
+        let server_pub = server_key.public_key();
+
+        let mut handshake = NoiseHandshake::new(machine_key, server_pub);
+        let req = ControlConnection::build_upgrade_request(
+            &mut handshake,
+            "https://controlplane.tailscale.com",
+        )
+        .expect("build_upgrade_request should succeed");
+
+        // URL should end with /ts2021
+        assert!(
+            req.url.ends_with("/ts2021"),
+            "URL should end with /ts2021: {}",
+            req.url
+        );
+        assert_eq!(req.url, "https://controlplane.tailscale.com/ts2021");
+
+        // Check headers
+        let header_map: std::collections::HashMap<&str, &str> = req
+            .headers
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
+        assert_eq!(
+            header_map.get("Upgrade"),
+            Some(&"tailscale-control-protocol")
+        );
+        assert_eq!(header_map.get("Connection"), Some(&"Upgrade"));
+        assert!(
+            header_map.contains_key("X-Tailscale-Handshake"),
+            "should have X-Tailscale-Handshake header"
+        );
+
+        // Handshake value should be valid base64
+        let handshake_b64 = header_map["X-Tailscale-Handshake"];
+        assert!(!handshake_b64.is_empty(), "handshake should be non-empty");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(handshake_b64)
+            .expect("handshake header should be valid base64");
+        assert!(
+            decoded.len() > 5,
+            "decoded handshake should contain framed noise message"
+        );
+    }
+
+    #[test]
+    fn build_upgrade_request_strips_trailing_slash() {
+        let machine_key = MachinePrivate::generate();
+        let server_key = MachinePrivate::generate();
+        let server_pub = server_key.public_key();
+
+        let mut handshake = NoiseHandshake::new(machine_key, server_pub);
+        let req = ControlConnection::build_upgrade_request(
+            &mut handshake,
+            "https://controlplane.tailscale.com/",
+        )
+        .expect("should succeed");
+
+        assert_eq!(req.url, "https://controlplane.tailscale.com/ts2021");
+    }
+
+    #[test]
+    fn send_encrypts_payload() {
+        // Build a full handshake to get a working ControlConnection
+        let machine_key = MachinePrivate::generate();
+        let server_key = MachinePrivate::generate();
+        let server_pub = server_key.public_key();
+
+        // Do the handshake manually through snow
+        let params: snow::params::NoiseParams = "Noise_IK_25519_ChaChaPoly_BLAKE2s"
+            .parse()
+            .expect("params should parse");
+        let prologue_bytes = "Tailscale Control Protocol v1".as_bytes();
+
+        let mut initiator = snow::Builder::new(params.clone())
+            .local_private_key(machine_key.as_bytes())
+            .expect("set key")
+            .remote_public_key(server_pub.as_bytes())
+            .expect("set remote key")
+            .prologue(prologue_bytes)
+            .expect("set prologue")
+            .build_initiator()
+            .expect("build initiator");
+
+        let params2: snow::params::NoiseParams = "Noise_IK_25519_ChaChaPoly_BLAKE2s"
+            .parse()
+            .expect("params should parse");
+
+        let mut responder = snow::Builder::new(params2)
+            .local_private_key(server_key.as_bytes())
+            .expect("set key")
+            .prologue(prologue_bytes)
+            .expect("set prologue")
+            .build_responder()
+            .expect("build responder");
+
+        let mut buf = vec![0u8; 65535];
+        let mut payload_buf = vec![0u8; 65535];
+
+        let len = initiator.write_message(&[], &mut buf).expect("write msg1");
+        responder
+            .read_message(&buf[..len], &mut payload_buf)
+            .expect("read msg1");
+
+        let len = responder.write_message(&[], &mut buf).expect("write msg2");
+        initiator
+            .read_message(&buf[..len], &mut payload_buf)
+            .expect("read msg2");
+
+        let client_transport = crate::noise::NoiseTransport::from_snow(
+            initiator
+                .into_transport_mode()
+                .expect("initiator transport"),
+        );
+
+        let mut conn = ControlConnection {
+            noise: client_transport,
+        };
+
+        let plaintext = b"test control message";
+        let encrypted = conn.send(plaintext).expect("send should succeed");
+
+        // Encrypted output should differ from plaintext
+        assert_ne!(
+            &encrypted[3..],
+            plaintext,
+            "encrypted payload should differ from plaintext"
+        );
+        // And should be longer (due to auth tag)
+        assert!(
+            encrypted.len() > plaintext.len(),
+            "encrypted should be longer than plaintext"
+        );
+    }
+}

--- a/crates/plegma-core/Cargo.toml
+++ b/crates/plegma-core/Cargo.toml
@@ -13,6 +13,9 @@ workspace = true
 [dependencies]
 snafu = { workspace = true }
 serde = { workspace = true }
+x25519-dalek = { workspace = true }
+zeroize = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/plegma-core/src/keys.rs
+++ b/crates/plegma-core/src/keys.rs
@@ -1,0 +1,267 @@
+//! Typed key wrappers for the Tailscale/WireGuard key hierarchy.
+//!
+//! All keys are Curve25519, 32 bytes. Each key type is a newtype that enforces
+//! correct usage: private keys are non-cloneable and zeroized on drop, public
+//! keys are freely cloneable and derive the standard traits.
+//!
+//! Serialization uses Tailscale's typed hex prefixes (`mkey:`, `nodekey:`,
+//! `discokey:`, `privkey:`).
+
+use core::fmt;
+
+use rand::rngs::OsRng;
+use x25519_dalek::{PublicKey, StaticSecret};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// Length of all Curve25519 keys in bytes.
+const KEY_LEN: usize = 32;
+
+// ---------------------------------------------------------------------------
+// Macro for reducing boilerplate across the three key pairs
+// ---------------------------------------------------------------------------
+
+macro_rules! key_pair {
+    (
+        private_name = $Priv:ident,
+        public_name  = $Pub:ident,
+        private_prefix = $priv_prefix:expr,
+        public_prefix  = $pub_prefix:expr,
+        doc_private    = $doc_priv:expr,
+        doc_public     = $doc_pub:expr,
+    ) => {
+        #[doc = $doc_priv]
+        pub struct $Priv([u8; KEY_LEN]);
+
+        // Manual Debug: redact private key material.
+        impl fmt::Debug for $Priv {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_tuple(stringify!($Priv))
+                    .field(&"[REDACTED]")
+                    .finish()
+            }
+        }
+
+        // Zeroize on drop for private keys.
+        impl Drop for $Priv {
+            fn drop(&mut self) {
+                self.0.zeroize();
+            }
+        }
+
+        impl ZeroizeOnDrop for $Priv {}
+
+        impl $Priv {
+            /// Generate a new random private key.
+            #[must_use]
+            pub fn generate() -> Self {
+                let secret = StaticSecret::random_from_rng(OsRng);
+                Self(secret.to_bytes())
+            }
+
+            /// Create a private key from raw bytes.
+            #[must_use]
+            pub fn from_bytes(bytes: [u8; KEY_LEN]) -> Self {
+                Self(bytes)
+            }
+
+            /// Borrow the raw key bytes.
+            #[must_use]
+            pub fn as_bytes(&self) -> &[u8; KEY_LEN] {
+                &self.0
+            }
+
+            /// Derive the corresponding public key.
+            #[must_use]
+            pub fn public_key(&self) -> $Pub {
+                let secret = StaticSecret::from(self.0);
+                let public = PublicKey::from(&secret);
+                $Pub(*public.as_bytes())
+            }
+
+            /// Serialize to hex with the Tailscale private-key prefix.
+            #[must_use]
+            pub fn to_hex(&self) -> String {
+                let hex = hex_encode(&self.0);
+                format!("{}{hex}", $priv_prefix)
+            }
+        }
+
+        #[doc = $doc_pub]
+        #[derive(Clone, PartialEq, Eq, Hash)]
+        pub struct $Pub([u8; KEY_LEN]);
+
+        impl fmt::Debug for $Pub {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_tuple(stringify!($Pub))
+                    .field(&self.to_hex())
+                    .finish()
+            }
+        }
+
+        impl $Pub {
+            /// Create a public key from raw bytes.
+            #[must_use]
+            pub fn from_bytes(bytes: [u8; KEY_LEN]) -> Self {
+                Self(bytes)
+            }
+
+            /// Borrow the raw key bytes.
+            #[must_use]
+            pub fn as_bytes(&self) -> &[u8; KEY_LEN] {
+                &self.0
+            }
+
+            /// Serialize to hex with the Tailscale public-key prefix.
+            #[must_use]
+            pub fn to_hex(&self) -> String {
+                let hex = hex_encode(&self.0);
+                format!("{}{hex}", $pub_prefix)
+            }
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Key pair definitions
+// ---------------------------------------------------------------------------
+
+key_pair! {
+    private_name   = MachinePrivate,
+    public_name    = MachinePublic,
+    private_prefix = "privkey:",
+    public_prefix  = "mkey:",
+    doc_private    = "Machine identity private key -- persisted to disk, never rotates.\n\nUsed for the Noise IK handshake with the control server.",
+    doc_public     = "Machine identity public key.\n\nSerialized with the `mkey:` prefix in the Tailscale protocol.",
+}
+
+key_pair! {
+    private_name   = NodePrivate,
+    public_name    = NodePublic,
+    private_prefix = "privkey:",
+    public_prefix  = "nodekey:",
+    doc_private    = "Node identity private key -- `WireGuard` identity. Rotates on expiry.\n\nUsed for `WireGuard` tunnels and DERP communication.",
+    doc_public     = "Node identity public key.\n\nSerialized with the `nodekey:` prefix in the Tailscale protocol.",
+}
+
+key_pair! {
+    private_name   = DiscoPrivate,
+    public_name    = DiscoPublic,
+    private_prefix = "privkey:",
+    public_prefix  = "discokey:",
+    doc_private    = "Disco ephemeral private key -- regenerated per process.\n\nUsed for NAT traversal via the disco protocol.",
+    doc_public     = "Disco ephemeral public key.\n\nSerialized with the `discokey:` prefix in the Tailscale protocol.",
+}
+
+// ---------------------------------------------------------------------------
+// Hex encoding helper (avoids pulling in the `hex` crate for one function)
+// ---------------------------------------------------------------------------
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        use fmt::Write;
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_machine_key_produces_32_bytes() {
+        let key = MachinePrivate::generate();
+        assert_eq!(key.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn public_key_derivation_is_deterministic() {
+        let priv_key = MachinePrivate::generate();
+        let pub1 = priv_key.public_key();
+        let pub2 = priv_key.public_key();
+        assert_eq!(pub1, pub2);
+    }
+
+    #[test]
+    fn private_key_debug_redacts() {
+        let key = MachinePrivate::generate();
+        let debug = format!("{key:?}");
+        assert!(
+            debug.contains("[REDACTED]"),
+            "debug output should redact key material: {debug}"
+        );
+        // The output should be like `MachinePrivate("[REDACTED]")` --
+        // no raw hex bytes or byte arrays leaked.
+        assert!(
+            !debug.contains("0x"),
+            "debug output should not contain raw hex: {debug}"
+        );
+    }
+
+    #[test]
+    fn from_bytes_round_trips() {
+        let original = MachinePrivate::generate();
+        let bytes = *original.as_bytes();
+        let restored = MachinePrivate::from_bytes(bytes);
+        assert_eq!(original.as_bytes(), restored.as_bytes());
+
+        let pub_original = original.public_key();
+        let pub_bytes = *pub_original.as_bytes();
+        let pub_restored = MachinePublic::from_bytes(pub_bytes);
+        assert_eq!(pub_original, pub_restored);
+    }
+
+    #[test]
+    fn to_hex_includes_prefix() {
+        let priv_key = MachinePrivate::generate();
+        let pub_key = priv_key.public_key();
+
+        let priv_hex = priv_key.to_hex();
+        assert!(priv_hex.starts_with("privkey:"), "private hex: {priv_hex}");
+        // prefix + 64 hex chars
+        assert_eq!(priv_hex.len(), "privkey:".len() + 64);
+
+        let pub_hex = pub_key.to_hex();
+        assert!(pub_hex.starts_with("mkey:"), "public hex: {pub_hex}");
+        assert_eq!(pub_hex.len(), "mkey:".len() + 64);
+
+        // Node key prefix
+        let node_priv = NodePrivate::generate();
+        let node_pub = node_priv.public_key();
+        assert!(node_pub.to_hex().starts_with("nodekey:"));
+
+        // Disco key prefix
+        let disco_priv = DiscoPrivate::generate();
+        let disco_pub = disco_priv.public_key();
+        assert!(disco_pub.to_hex().starts_with("discokey:"));
+    }
+
+    #[test]
+    fn different_keys_produce_different_public_keys() {
+        let key1 = MachinePrivate::generate();
+        let key2 = MachinePrivate::generate();
+        assert_ne!(key1.public_key(), key2.public_key());
+    }
+
+    #[test]
+    fn node_key_round_trips() {
+        let priv_key = NodePrivate::generate();
+        let bytes = *priv_key.as_bytes();
+        let restored = NodePrivate::from_bytes(bytes);
+        assert_eq!(priv_key.public_key(), restored.public_key());
+    }
+
+    #[test]
+    fn disco_key_round_trips() {
+        let priv_key = DiscoPrivate::generate();
+        let bytes = *priv_key.as_bytes();
+        let restored = DiscoPrivate::from_bytes(bytes);
+        assert_eq!(priv_key.public_key(), restored.public_key());
+    }
+}

--- a/crates/plegma-core/src/lib.rs
+++ b/crates/plegma-core/src/lib.rs
@@ -10,20 +10,4 @@
 
 #![deny(missing_docs)]
 
-/// Placeholder sentinel indicating the crate is reachable from the workspace.
-///
-/// Removed when the first real type module lands.
-#[must_use]
-pub const fn scaffold_sentinel() -> &'static str {
-    "plegma-core"
-}
-
-#[cfg(test)]
-mod tests {
-    use super::scaffold_sentinel;
-
-    #[test]
-    fn sentinel_returns_crate_name() {
-        assert_eq!(scaffold_sentinel(), "plegma-core");
-    }
-}
+pub mod keys;


### PR DESCRIPTION
First real dictyon implementation. Key types (Machine/Node/Disco with zeroize), Noise_IK handshake via snow, framed transport with Tailscale wire format, HTTP upgrade request builder. 15 tests.