### PR TITLE
fix: resolve 1 lint violations via local

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,11 @@ disallowed_types = "deny"
 snafu = "0.8"
 
 # TLS
-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "tls12"] }
+rustls = {
+    version = "0.23",
+    default-features = false,
+    features = ["logging", "ring", "tls12"],
+}
 tokio-rustls = { version = "0.26", default-features = false }
 webpki-roots = "1"
 


### PR DESCRIPTION
Mechanical lint fixes by Qwen3.5-35B-A3B-Q8_0.

**Violations:** 1 | **Files:** 1
**Rules:** TOML/inline-table-too-long

Gate-Passed: kanon 0.1.0