### PR TITLE
chore: parameterize behavioral constants (closes #7)

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -11,13 +11,16 @@ CI/no-format-check:.github/workflows/**
 CI/no-test-step:.github/workflows/**
 
 # hamma-core exports the key hierarchy (MachinePrivate/Public, NodePrivate/Public,
-# DiscoPrivate/Public, MachinePublic::from_hex) and Tailscale-compatible wire types
-# (RegisterRequest, MapRequest, Node, Hostinfo, DnsConfig, DerpMap, ...) that
-# dictyon (and future `histos`) consume by name. Every `pub` here IS the library
-# contract — pub(crate) would hide it from the other workspace crate. See
-# crates/dictyon/src/*.rs imports of `hamma_core::{keys,types}::*`.
+# DiscoPrivate/Public, MachinePublic::from_hex), Tailscale-compatible wire types
+# (RegisterRequest, MapRequest, Node, Hostinfo, DnsConfig, DerpMap, ...), and the
+# behavioral Config (WireConfig, NoiseConfig, and the DEFAULT_* constants
+# documenting their values) that dictyon (and future `histos`) consume by name.
+# Every `pub` here IS the library contract — pub(crate) would hide it from the
+# other workspace crate. See crates/dictyon/src/*.rs imports of
+# `hamma_core::{keys,types,config}::*`.
 RUST/pub-visibility:crates/hamma-core/src/keys.rs
 RUST/pub-visibility:crates/hamma-core/src/types.rs
+RUST/pub-visibility:crates/hamma-core/src/config.rs
 
 # dictyon's public surface (ControlClient, Netmap, RegisterOutcome, NoiseHandshake,
 # NoiseTransport, ControlConnection, UpgradeRequest, AsyncControlStream, ControlConfig,

--- a/crates/dictyon/examples/connect.rs
+++ b/crates/dictyon/examples/connect.rs
@@ -123,10 +123,10 @@ async fn run() -> Result<(), ExampleError> {
 
     info!("connecting to {CONTROL_URL}");
 
-    let config = ControlConfig {
-        control_url: CONTROL_URL.to_string(),
-        machine_key: MachinePrivate::from_bytes(*machine_key.as_bytes()),
-    };
+    let config = ControlConfig::new(
+        CONTROL_URL.to_string(),
+        MachinePrivate::from_bytes(*machine_key.as_bytes()),
+    );
 
     let mut stream = connect(&config).await?;
     info!("TLS + Noise handshake complete");

--- a/crates/dictyon/src/noise/mod.rs
+++ b/crates/dictyon/src/noise/mod.rs
@@ -13,14 +13,29 @@
 //!
 //! See `control/controlbase/` in the Tailscale Go source for reference.
 
+use hamma_core::config::NoiseConfig;
 use hamma_core::keys::{MachinePrivate, MachinePublic};
 use snafu::Snafu;
 use snow::{Builder, HandshakeState, TransportState};
 
+// ---------------------------------------------------------------------------
+// Protocol-fixed constants (NOT parameterizable)
+// ---------------------------------------------------------------------------
+//
+// Each constant below is a wire-format or cryptographic invariant: changing
+// it is a protocol break, not a tuning operation. They stay `const` at the
+// module scope so the boundary between "what the peer expects" and "what
+// the operator may tune" is syntactically obvious.
+
 /// Noise protocol parameters for the Tailscale control plane.
+///
+/// Cryptographic invariant: changing this changes the handshake algorithm
+/// and breaks wire compatibility with every peer. Do not parameterize.
 const NOISE_PARAMS: &str = "Noise_IK_25519_ChaChaPoly_BLAKE2s";
 
 /// Current protocol version for the Noise handshake.
+///
+/// Wire-format invariant: peers key their prologue off this value.
 const PROTOCOL_VERSION: u16 = 1;
 
 /// Message type for the initiator's first message.
@@ -32,11 +47,14 @@ const MSG_TYPE_RESPONSE: u8 = 0x02;
 /// Message type for post-handshake transport frames.
 const MSG_TYPE_TRANSPORT: u8 = 0x04;
 
-/// Maximum Noise transport frame payload size (before encryption).
-const MAX_FRAME_PAYLOAD: usize = 4096;
-
 /// Poly1305 tag length added by AEAD encryption.
+///
+/// Cryptographic invariant of ChaCha20-Poly1305. Do not parameterize.
 const TAG_LEN: usize = 16;
+
+// Tuning knobs (payload size, scratch-buffer size) live on
+// [`hamma_core::config::NoiseConfig`]. See [`NoiseHandshake::with_config`]
+// and [`NoiseTransport::encrypt`] for consumption.
 
 /// Prologue mixed into the handshake hash, binding the session to the
 /// Tailscale control protocol and its version.
@@ -95,6 +113,7 @@ impl From<snow::Error> for NoiseError {
 ///    server's response to complete the handshake.
 pub struct NoiseHandshake {
     state: HandshakePhase,
+    config: NoiseConfig,
 }
 
 /// Internal state machine for the handshake.
@@ -118,11 +137,27 @@ impl NoiseHandshake {
     /// * `machine_key` - The client's machine identity key.
     /// * `server_public` - The server's static public key (from `/key?v=N`).
     pub fn new(machine_key: MachinePrivate, server_public: MachinePublic) -> Self {
+        Self::with_config(machine_key, server_public, NoiseConfig::default())
+    }
+
+    /// Create a new handshake initiator with a custom [`NoiseConfig`].
+    ///
+    /// # Arguments
+    ///
+    /// * `machine_key` - The client's machine identity key.
+    /// * `server_public` - The server's static public key (from `/key?v=N`).
+    /// * `config` - Framing tuning knobs (scratch buffer sizes, payload cap).
+    pub fn with_config(
+        machine_key: MachinePrivate,
+        server_public: MachinePublic,
+        config: NoiseConfig,
+    ) -> Self {
         Self {
             state: HandshakePhase::Ready {
                 machine_key,
                 server_public,
             },
+            config,
         }
     }
 
@@ -160,8 +195,9 @@ impl NoiseHandshake {
 
         // IK message 1: e, es, s, ss
         // snow needs a buffer large enough for the handshake message.
-        // IK msg1 = 32 (ephemeral pub) + 32 (static pub encrypted) + 16 (tag) + 16 (empty payload tag) = 96
-        let mut noise_msg = vec![0u8; 256];
+        // IK msg1 = 32 (ephemeral pub) + 32 (static pub encrypted) + 16 (tag) + 16 (empty payload tag) = 96.
+        // Scratch buffer size is a tuning knob -- see NoiseConfig::handshake_scratch_bytes.
+        let mut noise_msg = vec![0u8; self.config.handshake_scratch_bytes];
         let noise_len = handshake.write_message(&[], &mut noise_msg)?;
         noise_msg.truncate(noise_len);
 
@@ -193,6 +229,7 @@ impl NoiseHandshake {
     /// [`NoiseError::Snow`] / [`NoiseError::HandshakeFailed`] if the
     /// response is invalid.
     pub fn process_response(mut self, response: &[u8]) -> Result<NoiseTransport, NoiseError> {
+        let config = self.config.clone();
         let mut handshake = match core::mem::replace(&mut self.state, HandshakePhase::Completed) {
             HandshakePhase::AwaitingResponse { handshake } => *handshake,
             HandshakePhase::Ready { .. } => {
@@ -231,12 +268,13 @@ impl NoiseHandshake {
                 })?;
 
         // IK message 2: e, ee, se
-        let mut payload_buf = vec![0u8; 256];
+        // Scratch buffer size is a tuning knob -- see NoiseConfig::handshake_scratch_bytes.
+        let mut payload_buf = vec![0u8; config.handshake_scratch_bytes];
         let _payload_len = handshake.read_message(noise_msg, &mut payload_buf)?;
 
         let transport = handshake.into_transport_mode()?;
 
-        Ok(NoiseTransport { transport })
+        Ok(NoiseTransport { transport, config })
     }
 }
 
@@ -246,6 +284,7 @@ impl NoiseHandshake {
 /// `[1B type=0x04][2B BE length][ciphertext]`.
 pub struct NoiseTransport {
     transport: TransportState,
+    config: NoiseConfig,
 }
 
 impl NoiseTransport {
@@ -259,12 +298,10 @@ impl NoiseTransport {
     /// the maximum frame payload size, or [`NoiseError::Snow`] on
     /// encryption failure.
     pub fn encrypt(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, NoiseError> {
-        if plaintext.len() > MAX_FRAME_PAYLOAD {
+        let max_payload = self.config.max_frame_payload;
+        if plaintext.len() > max_payload {
             return Err(NoiseError::HandshakeFailed {
-                message: format!(
-                    "payload too large: {} > {MAX_FRAME_PAYLOAD}",
-                    plaintext.len()
-                ),
+                message: format!("payload too large: {} > {max_payload}", plaintext.len()),
             });
         }
 
@@ -323,7 +360,20 @@ impl NoiseTransport {
     /// paired transport state without going through the full handshake flow.
     #[doc(hidden)]
     pub fn from_snow(transport: TransportState) -> Self {
-        Self { transport }
+        Self {
+            transport,
+            config: NoiseConfig::default(),
+        }
+    }
+
+    /// Construct a [`NoiseTransport`] from a raw `snow::TransportState` with
+    /// a custom [`NoiseConfig`].
+    ///
+    /// Exposed for tests that need to exercise non-default framing limits
+    /// without running the full handshake.
+    #[doc(hidden)]
+    pub fn from_snow_with_config(transport: TransportState, config: NoiseConfig) -> Self {
+        Self { transport, config }
     }
 }
 

--- a/crates/dictyon/src/noise/tests.rs
+++ b/crates/dictyon/src/noise/tests.rs
@@ -8,7 +8,14 @@
     reason = "tests use expect() for invariants that must hold"
 )]
 
+use hamma_core::config::DEFAULT_MAX_FRAME_PAYLOAD;
+
 use super::*;
+
+/// Legacy alias for the default max-frame-payload; kept local to the test
+/// module so existing test bodies stay readable without re-importing the
+/// full `NoiseConfig` default path at every use site.
+const MAX_FRAME_PAYLOAD: usize = DEFAULT_MAX_FRAME_PAYLOAD;
 
 /// Helper: build a snow responder for testing against our initiator.
 fn build_responder(server_private: &[u8; 32]) -> Result<HandshakeState, NoiseError> {
@@ -426,11 +433,50 @@ proptest::proptest! {
 }
 
 // -----------------------------------------------------------------------
+// Config-driven behavior tests
+// -----------------------------------------------------------------------
+
+/// A non-default `NoiseConfig` must change observable behavior: tightening
+/// `max_frame_payload` rejects a payload that the default would accept.
+#[test]
+fn noise_config_tightens_frame_payload_limit() {
+    use hamma_core::config::NoiseConfig;
+
+    // Size chosen to be well below the default (4 KiB) but above the
+    // custom limit, so the same payload passes default and fails custom.
+    let custom_limit = 128;
+    let plaintext = vec![0xABu8; 256];
+
+    // Baseline: default config accepts 256-byte payload.
+    let (mut default_client, _) = paired_transports();
+    default_client
+        .encrypt(&plaintext)
+        .expect("default config should accept 256-byte payload");
+
+    // Custom: build a transport with a tightened limit and prove it rejects
+    // the same payload. Re-using the paired_transports helper and then
+    // swapping to a custom-config variant via from_snow_with_config keeps
+    // the handshake plumbing reused.
+    let (client_state, _server_state) = paired_snow_transports();
+    let mut custom_cfg = NoiseConfig::default();
+    custom_cfg.max_frame_payload = custom_limit;
+    let mut custom_client = NoiseTransport::from_snow_with_config(client_state, custom_cfg);
+    let result = custom_client.encrypt(&plaintext);
+    assert!(
+        result.is_err(),
+        "custom config with max_frame_payload={custom_limit} must reject {}-byte payload",
+        plaintext.len()
+    );
+}
+
+// -----------------------------------------------------------------------
 // Shared helpers
 // -----------------------------------------------------------------------
 
-/// Helper: perform a full handshake and return paired transport states.
-fn paired_transports() -> (NoiseTransport, NoiseTransport) {
+/// Helper: perform a full handshake and return paired raw snow transport
+/// states. Lets callers wrap with whichever [`NoiseConfig`] they want to
+/// exercise.
+fn paired_snow_transports() -> (TransportState, TransportState) {
     let machine_key = MachinePrivate::generate();
     let server_key = MachinePrivate::generate();
     let server_pub = server_key.public_key();
@@ -478,16 +524,22 @@ fn paired_transports() -> (NoiseTransport, NoiseTransport) {
         .read_message(&buf[..len], &mut payload)
         .expect("read msg2");
 
-    let client = NoiseTransport::from_snow(
-        initiator
-            .into_transport_mode()
-            .expect("initiator transport"),
-    );
-    let server = NoiseTransport::from_snow(
-        responder
-            .into_transport_mode()
-            .expect("responder transport"),
-    );
+    let client_state = initiator
+        .into_transport_mode()
+        .expect("initiator transport");
+    let server_state = responder
+        .into_transport_mode()
+        .expect("responder transport");
 
-    (client, server)
+    (client_state, server_state)
+}
+
+/// Helper: perform a full handshake and return paired transport states
+/// wrapped with default `NoiseConfig`.
+fn paired_transports() -> (NoiseTransport, NoiseTransport) {
+    let (client_state, server_state) = paired_snow_transports();
+    (
+        NoiseTransport::from_snow(client_state),
+        NoiseTransport::from_snow(server_state),
+    )
 }

--- a/crates/dictyon/src/wire.rs
+++ b/crates/dictyon/src/wire.rs
@@ -20,6 +20,7 @@
 use std::sync::Arc;
 
 use base64::Engine;
+use hamma_core::config::{Config, WireConfig};
 use hamma_core::keys::{KeyError, MachinePrivate, MachinePublic};
 use rustls::ClientConfig;
 use snafu::{ResultExt, Snafu};
@@ -31,23 +32,30 @@ use crate::noise::NoiseHandshake;
 use crate::transport::ControlConnection;
 
 // ---------------------------------------------------------------------------
-// Constants
+// Protocol-fixed constants (NOT parameterizable)
 // ---------------------------------------------------------------------------
+//
+// The path, upgrade-header value, key-endpoint version, and frame-type byte
+// are wire-contract values: changing any of them breaks compatibility with
+// every tailscale-compatible control server. They stay `const` here so the
+// intent is syntactically obvious.
 
-/// Noise upgrade path.
+/// Noise upgrade path (Tailscale ts2021 wire contract).
 const UPGRADE_PATH: &str = "/ts2021";
 
-/// Key endpoint path (v=71 is the protocol version dictyon speaks).
+/// Key endpoint path. `v=71` is the wire version dictyon speaks; bumping
+/// it is a protocol break, not a tuning operation.
 const KEY_PATH: &str = "/key?v=71";
 
 /// HTTP Upgrade header value for the Tailscale control protocol.
 const UPGRADE_HEADER: &str = "tailscale-control-protocol";
 
-/// Maximum HTTP response header block we'll buffer (8 KiB).
-const MAX_HEADER_BYTES: usize = 8192;
-
 /// Transport frame type byte for post-handshake messages.
 const FRAME_TYPE_TRANSPORT: u8 = 0x04;
+
+// Tuning knobs (max header bytes, read chunk size, buffer capacity hints)
+// live on [`hamma_core::config::WireConfig`]. The free functions below
+// accept a `&Config` or fall back to `Config::default()`.
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -137,6 +145,27 @@ pub struct ControlConfig {
     pub control_url: String,
     /// This machine's private key.
     pub machine_key: MachinePrivate,
+    /// Behavioral tuning knobs (buffer sizes, timeouts, framing limits).
+    ///
+    /// Defaults to [`Config::default`]; override to expose operator-set or
+    /// agent-queried values to the wire and Noise layers.
+    pub config: Config,
+}
+
+impl ControlConfig {
+    /// Build a [`ControlConfig`] with default tuning knobs.
+    ///
+    /// Equivalent to setting `config: Config::default()` in a struct literal
+    /// and kept as the one-call-site constructor for callers that only care
+    /// about URL + key.
+    #[must_use]
+    pub fn new(control_url: String, machine_key: MachinePrivate) -> Self {
+        Self {
+            control_url,
+            machine_key,
+            config: Config::default(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -224,11 +253,28 @@ impl AsyncControlStream {
 
 /// Fetch the control server's public machine key from `GET /key?v=71`.
 ///
+/// Uses [`WireConfig::default`] for buffer/limit knobs. For a caller-tuned
+/// variant see [`fetch_server_key_with_config`].
+///
 /// # Errors
 ///
 /// Returns [`WireError`] on TCP/TLS failure, JSON parse failure, or if the
 /// returned key cannot be parsed.
 pub async fn fetch_server_key(control_url: &str) -> Result<MachinePublic, WireError> {
+    fetch_server_key_with_config(control_url, &WireConfig::default()).await
+}
+
+/// Fetch the control server's public machine key using a caller-supplied
+/// [`WireConfig`] for I/O buffer/limit tuning.
+///
+/// # Errors
+///
+/// Returns [`WireError`] on TCP/TLS failure, JSON parse failure, or if the
+/// returned key cannot be parsed.
+pub async fn fetch_server_key_with_config(
+    control_url: &str,
+    cfg: &WireConfig,
+) -> Result<MachinePublic, WireError> {
     let (host, port) = parse_host_port(control_url)?;
     let tls = build_tls_config();
     let connector = TlsConnector::from(Arc::new(tls));
@@ -254,18 +300,21 @@ pub async fn fetch_server_key(control_url: &str) -> Result<MachinePublic, WireEr
         .await
         .context(TlsSnafu)?;
 
-    let response = read_full_response(&mut tls_stream).await?;
+    let response = read_full_response(&mut tls_stream, cfg).await?;
     parse_server_key_response(&response)
 }
 
 /// Connect to the control server, complete the Noise IK handshake, and
 /// return an [`AsyncControlStream`] ready for control messages.
 ///
+/// Uses the tuning knobs on `config.config`. Default-construct `ControlConfig`
+/// with [`Config::default`] to match pre-config behavior.
+///
 /// # Errors
 ///
 /// Returns [`WireError`] on any I/O, TLS, HTTP, or Noise failure.
 pub async fn connect(config: &ControlConfig) -> Result<AsyncControlStream, WireError> {
-    let server_key = fetch_server_key(&config.control_url).await?;
+    let server_key = fetch_server_key_with_config(&config.control_url, &config.config.wire).await?;
     connect_with_key(config, server_key).await
 }
 
@@ -282,11 +331,18 @@ pub async fn connect_with_tls(
     config: &ControlConfig,
     tls_config: ClientConfig,
 ) -> Result<AsyncControlStream, WireError> {
-    let server_key = fetch_server_key_with_tls(&config.control_url, tls_config.clone()).await?;
+    let server_key = fetch_server_key_with_tls_and_config(
+        &config.control_url,
+        tls_config.clone(),
+        &config.config.wire,
+    )
+    .await?;
     connect_with_key_and_tls(config, server_key, tls_config).await
 }
 
 /// Fetch the server key using a caller-supplied TLS config.
+///
+/// Uses [`WireConfig::default`] for buffer/limit knobs.
 ///
 /// # Errors
 ///
@@ -295,6 +351,21 @@ pub async fn connect_with_tls(
 pub async fn fetch_server_key_with_tls(
     control_url: &str,
     tls_config: ClientConfig,
+) -> Result<MachinePublic, WireError> {
+    fetch_server_key_with_tls_and_config(control_url, tls_config, &WireConfig::default()).await
+}
+
+/// Fetch the server key using caller-supplied TLS config *and* wire-layer
+/// tuning knobs.
+///
+/// # Errors
+///
+/// Returns [`WireError`] on TCP/TLS failure, JSON parse failure, or if the
+/// returned key cannot be parsed.
+pub async fn fetch_server_key_with_tls_and_config(
+    control_url: &str,
+    tls_config: ClientConfig,
+    cfg: &WireConfig,
 ) -> Result<MachinePublic, WireError> {
     let (host, port) = parse_host_port(control_url)?;
     let connector = TlsConnector::from(Arc::new(tls_config));
@@ -320,7 +391,7 @@ pub async fn fetch_server_key_with_tls(
         .await
         .context(TlsSnafu)?;
 
-    let response = read_full_response(&mut tls_stream).await?;
+    let response = read_full_response(&mut tls_stream, cfg).await?;
     parse_server_key_response(&response)
 }
 
@@ -360,9 +431,10 @@ async fn connect_with_key_and_tls(
         .await
         .context(TlsSnafu)?;
 
-    // Build Noise initiation.
+    // Build Noise initiation using the handshake/framing knobs.
     let machine_key_copy = MachinePrivate::from_bytes(*config.machine_key.as_bytes());
-    let mut handshake = NoiseHandshake::new(machine_key_copy, server_key);
+    let mut handshake =
+        NoiseHandshake::with_config(machine_key_copy, server_key, config.config.noise.clone());
     let init_msg = handshake.initiation_message()?;
     let init_b64 = base64::engine::general_purpose::STANDARD.encode(&init_msg);
 
@@ -374,7 +446,7 @@ async fn connect_with_key_and_tls(
         .context(TlsSnafu)?;
 
     // Read HTTP headers; the Noise response frame follows in the stream.
-    let (status_line, _) = read_upgrade_response(&mut tls_stream).await?;
+    let (status_line, _) = read_upgrade_response(&mut tls_stream, &config.config.wire).await?;
 
     if !status_line.contains("101") {
         return Err(WireError::UnexpectedStatus { status_line });
@@ -505,8 +577,9 @@ async fn read_noise_response_frame(
 /// Read until `\r\n\r\n`, returning (`first_line`, `bytes_after_headers`).
 async fn read_upgrade_response(
     stream: &mut tokio_rustls::client::TlsStream<TcpStream>,
+    cfg: &WireConfig,
 ) -> Result<(String, Vec<u8>), WireError> {
-    let buf = read_until_header_end(stream).await?;
+    let buf = read_until_header_end(stream, cfg).await?;
 
     // Split at the header terminator.
     let sep = b"\r\n\r\n";
@@ -542,17 +615,19 @@ async fn read_upgrade_response(
 /// Read from the stream until we see `\r\n\r\n` or hit the size limit.
 async fn read_until_header_end(
     stream: &mut tokio_rustls::client::TlsStream<TcpStream>,
+    cfg: &WireConfig,
 ) -> Result<Vec<u8>, WireError> {
-    let mut buf = Vec::with_capacity(512);
+    let max_header_bytes = cfg.max_header_bytes;
+    let mut buf = Vec::with_capacity(cfg.header_read_initial_capacity);
     let mut byte = [0u8; 1];
 
     loop {
         stream.read_exact(&mut byte).await.context(TlsSnafu)?;
         buf.extend_from_slice(&byte);
 
-        if buf.len() > MAX_HEADER_BYTES {
+        if buf.len() > max_header_bytes {
             return Err(WireError::MalformedHeaders {
-                message: format!("headers exceeded {MAX_HEADER_BYTES} bytes"),
+                message: format!("headers exceeded {max_header_bytes} bytes"),
             });
         }
 
@@ -572,9 +647,11 @@ async fn read_until_header_end(
 /// Read the full HTTP/1.1 response body (for the /key endpoint).
 async fn read_full_response(
     stream: &mut tokio_rustls::client::TlsStream<TcpStream>,
+    cfg: &WireConfig,
 ) -> Result<Vec<u8>, WireError> {
+    let max_body = cfg.key_response_max_bytes();
     let mut buf = Vec::new();
-    let mut chunk = [0u8; 4096];
+    let mut chunk = vec![0u8; cfg.response_read_chunk_bytes];
     loop {
         match stream.read(&mut chunk).await {
             Ok(0) => break,
@@ -586,7 +663,7 @@ async fn read_full_response(
             }
             Err(e) => return Err(WireError::Tls { source: e }),
         }
-        if buf.len() > MAX_HEADER_BYTES * 4 {
+        if buf.len() > max_body {
             return Err(WireError::KeyParse {
                 message: "response too large".to_string(),
             });

--- a/crates/dictyon/tests/wire_integration.rs
+++ b/crates/dictyon/tests/wire_integration.rs
@@ -300,10 +300,10 @@ async fn connects_and_completes_noise_handshake() {
         // Handshake complete — test just verifies connect() returns Ok.
     });
 
-    let config = dictyon::wire::ControlConfig {
-        control_url: format!("https://127.0.0.1:{}", addr.port()),
-        machine_key: MachinePrivate::generate(),
-    };
+    let config = dictyon::wire::ControlConfig::new(
+        format!("https://127.0.0.1:{}", addr.port()),
+        MachinePrivate::generate(),
+    );
 
     let result = dictyon::wire::connect_with_tls(&config, client_tls_cfg).await;
     assert!(result.is_ok(), "connect_with_tls should succeed");
@@ -399,10 +399,10 @@ async fn register_returns_authorized_with_preauth_key() {
     let node_key = hamma_core::keys::NodePrivate::generate();
     let disco_key = hamma_core::keys::DiscoPrivate::generate();
 
-    let config = dictyon::wire::ControlConfig {
-        control_url: format!("https://127.0.0.1:{}", addr.port()),
-        machine_key: MachinePrivate::from_bytes(*machine_key.as_bytes()),
-    };
+    let config = dictyon::wire::ControlConfig::new(
+        format!("https://127.0.0.1:{}", addr.port()),
+        MachinePrivate::from_bytes(*machine_key.as_bytes()),
+    );
 
     let mut stream = dictyon::wire::connect_with_tls(&config, client_tls_cfg)
         .await
@@ -429,10 +429,10 @@ async fn register_returns_authorized_with_preauth_key() {
 #[tokio::test]
 async fn connection_to_unreachable_host_returns_error() {
     // Port 1 is reserved; connection should fail immediately.
-    let config = dictyon::wire::ControlConfig {
-        control_url: "https://127.0.0.1:1".to_string(),
-        machine_key: MachinePrivate::generate(),
-    };
+    let config = dictyon::wire::ControlConfig::new(
+        "https://127.0.0.1:1".to_string(),
+        MachinePrivate::generate(),
+    );
 
     // Use the default (webpki) TLS config — we expect a TCP connect failure
     // before TLS is even attempted.

--- a/crates/hamma-core/src/config.rs
+++ b/crates/hamma-core/src/config.rs
@@ -1,0 +1,318 @@
+//! Behavioral configuration for the hamma stack.
+//!
+//! Every field in [`Config`] is a **tuning knob** — a value that a reasonable
+//! operator (or an agent, via aletheia's parameter registry, forkwright/hamma#7)
+//! might want to change without recompiling. Values documented here match the
+//! current hard-coded defaults; changing the default here changes the default
+//! everywhere.
+//!
+//! # What is NOT here
+//!
+//! Cryptographic invariants (key lengths, AEAD tag sizes, Noise handshake
+//! parameters) and protocol-fixed constants (message type bytes, HTTP upgrade
+//! path, wire-format version numbers) are **not** exposed as config. Changing
+//! them is a protocol-break, not a tuning operation, so they remain `const`
+//! next to the code that relies on their immutability.
+//!
+//! # Discoverability
+//!
+//! The doc-comment on each field is the agent-facing description. It should
+//! explain:
+//! 1. What the value controls,
+//! 2. The unit (bytes, count, ms, …),
+//! 3. A reasonable range,
+//! 4. What symptom would motivate changing it.
+//!
+//! # Extensibility
+//!
+//! [`Config`] and its nested sub-configs are marked `#[non_exhaustive]` so
+//! adding new knobs is not a breaking change. Construct instances through the
+//! `Default` impl (and then mutate fields) or by using [`serde`] to load from
+//! a file.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+//
+// Named constants so the defaults are inspectable from code and the comments
+// double as the canonical rationale.
+
+/// Default cap on HTTP response header block size (8 KiB).
+///
+/// Large enough for typical `GET /key` and `101 Switching Protocols`
+/// responses, small enough to bound memory if the peer misbehaves.
+pub const DEFAULT_MAX_HEADER_BYTES: usize = 8 * 1024;
+
+/// Default cap on total `/key` response body size, expressed as a multiple
+/// of the header cap. 4× the header cap accommodates large JSON responses
+/// without permitting unbounded reads.
+pub const DEFAULT_KEY_RESPONSE_BODY_MULTIPLIER: usize = 4;
+
+/// Default initial capacity for the header-scan buffer (512 bytes).
+///
+/// A single-hint allocation; the buffer grows as needed up to the cap.
+pub const DEFAULT_HEADER_READ_INITIAL_CAPACITY: usize = 512;
+
+/// Default read chunk size when draining an HTTP response body (4 KiB).
+///
+/// Matches a common page size and plays well with TLS record sizes.
+pub const DEFAULT_RESPONSE_READ_CHUNK_BYTES: usize = 4096;
+
+/// Default cap on a single Noise transport frame payload (4 KiB plaintext).
+///
+/// This bounds the size of a control-protocol message; larger messages must
+/// be split by the caller. Must not exceed `u16::MAX - TAG_LEN` because the
+/// wire framing uses a `u16` length.
+pub const DEFAULT_MAX_FRAME_PAYLOAD: usize = 4096;
+
+/// Default scratch-buffer size for serialising/deserialising Noise handshake
+/// messages (256 bytes).
+///
+/// An IK `msg1`/`msg2` is ≤ 96 bytes; 256 gives headroom for payload-bearing
+/// handshakes without over-allocating.
+pub const DEFAULT_HANDSHAKE_SCRATCH_BYTES: usize = 256;
+
+// ---------------------------------------------------------------------------
+// WireConfig
+// ---------------------------------------------------------------------------
+
+/// Tuning knobs for the wire layer (TCP/TLS/HTTP upgrade I/O).
+///
+/// Applies to [`dictyon::wire`](../../dictyon/wire/index.html) — the module
+/// that owns raw socket I/O and the HTTP upgrade handshake.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct WireConfig {
+    /// Maximum HTTP response header block we will buffer, in bytes.
+    ///
+    /// **Controls:** memory bound for header parsing; attacker-resilience.
+    /// **Range:** `[1024, 65_536]` — below 1 KiB breaks legitimate control
+    /// servers; above 64 KiB is wasted memory per connection.
+    /// **Default:** 8 KiB. Raise if a control server sends very large
+    /// header blocks (e.g. many cookies); lower to harden against abuse.
+    pub max_header_bytes: usize,
+
+    /// Multiplier applied to `max_header_bytes` to cap the total
+    /// `/key` endpoint response size.
+    ///
+    /// **Controls:** upper bound on untrusted JSON body size before parse.
+    /// **Range:** `[1, 16]`.
+    /// **Default:** 4 (= 32 KiB at default header cap). Raise only if a
+    /// control server ships a very large key-discovery JSON body.
+    pub key_response_body_multiplier: usize,
+
+    /// Initial capacity hint for the header-scan buffer, in bytes.
+    ///
+    /// **Controls:** number of allocations during header read on small
+    /// responses. Does not cap size — that is `max_header_bytes`.
+    /// **Range:** `[64, max_header_bytes]`.
+    /// **Default:** 512.
+    pub header_read_initial_capacity: usize,
+
+    /// Chunk size for reads while draining an HTTP response body, in bytes.
+    ///
+    /// **Controls:** syscall/read granularity while collecting body bytes.
+    /// **Range:** `[512, 65_536]`.
+    /// **Default:** 4 KiB. Increase for high-throughput links; decrease for
+    /// memory-constrained environments.
+    pub response_read_chunk_bytes: usize,
+}
+
+impl Default for WireConfig {
+    fn default() -> Self {
+        Self {
+            max_header_bytes: DEFAULT_MAX_HEADER_BYTES,
+            key_response_body_multiplier: DEFAULT_KEY_RESPONSE_BODY_MULTIPLIER,
+            header_read_initial_capacity: DEFAULT_HEADER_READ_INITIAL_CAPACITY,
+            response_read_chunk_bytes: DEFAULT_RESPONSE_READ_CHUNK_BYTES,
+        }
+    }
+}
+
+impl WireConfig {
+    /// Return the maximum permitted `/key` response body size in bytes.
+    ///
+    /// Derived as `max_header_bytes * key_response_body_multiplier`.
+    #[must_use]
+    pub fn key_response_max_bytes(&self) -> usize {
+        self.max_header_bytes
+            .saturating_mul(self.key_response_body_multiplier)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NoiseConfig
+// ---------------------------------------------------------------------------
+
+/// Tuning knobs for the Noise transport framing layer.
+///
+/// These are **framing** limits, not cryptographic parameters. The Noise
+/// pattern, AEAD tag length, and message-type bytes are protocol invariants
+/// and remain `const` inside `dictyon::noise`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct NoiseConfig {
+    /// Maximum plaintext payload per Noise transport frame, in bytes.
+    ///
+    /// **Controls:** largest single control-plane message that can be sent
+    /// without caller-side chunking.
+    /// **Range:** `[256, 65_519]` — the wire format uses a `u16` length;
+    /// the 16-byte Poly1305 tag is added on top, so the absolute ceiling is
+    /// `u16::MAX - 16 = 65_519`.
+    /// **Default:** 4 KiB — matches the reference implementation and most
+    /// control-plane message sizes.
+    pub max_frame_payload: usize,
+
+    /// Scratch buffer size for Noise IK handshake serialisation, in bytes.
+    ///
+    /// **Controls:** size of the temporary buffer passed to `snow` during
+    /// `write_message`/`read_message`. Must be ≥ the largest handshake
+    /// message (≤ 96 bytes for IK without payload).
+    /// **Range:** `[128, 4096]`.
+    /// **Default:** 256 — leaves headroom for payload-bearing IK variants.
+    pub handshake_scratch_bytes: usize,
+}
+
+impl Default for NoiseConfig {
+    fn default() -> Self {
+        Self {
+            max_frame_payload: DEFAULT_MAX_FRAME_PAYLOAD,
+            handshake_scratch_bytes: DEFAULT_HANDSHAKE_SCRATCH_BYTES,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level Config
+// ---------------------------------------------------------------------------
+
+/// Top-level hamma configuration — a flat, persistable snapshot of every
+/// behavioral tuning knob across the stack.
+///
+/// Construct via [`Config::default`] and mutate individual fields, or load
+/// from TOML/JSON through [`serde`]. All sub-configs are independently
+/// defaulted so partial construction is always valid.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+#[non_exhaustive]
+pub struct Config {
+    /// Wire-layer (TCP/TLS/HTTP) tuning knobs.
+    pub wire: WireConfig,
+
+    /// Noise transport framing knobs.
+    pub noise: NoiseConfig,
+}
+
+impl Config {
+    /// Construct a new [`Config`] with all defaults.
+    ///
+    /// Equivalent to [`Config::default`], provided for fluent call sites.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "tests use expect() for invariants that must hold"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values_match_documented_constants() {
+        let c = Config::default();
+        assert_eq!(c.wire.max_header_bytes, DEFAULT_MAX_HEADER_BYTES);
+        assert_eq!(
+            c.wire.key_response_body_multiplier,
+            DEFAULT_KEY_RESPONSE_BODY_MULTIPLIER
+        );
+        assert_eq!(
+            c.wire.header_read_initial_capacity,
+            DEFAULT_HEADER_READ_INITIAL_CAPACITY
+        );
+        assert_eq!(
+            c.wire.response_read_chunk_bytes,
+            DEFAULT_RESPONSE_READ_CHUNK_BYTES
+        );
+        assert_eq!(c.noise.max_frame_payload, DEFAULT_MAX_FRAME_PAYLOAD);
+        assert_eq!(
+            c.noise.handshake_scratch_bytes,
+            DEFAULT_HANDSHAKE_SCRATCH_BYTES
+        );
+    }
+
+    #[test]
+    fn key_response_max_bytes_is_derived() {
+        let c = WireConfig::default();
+        assert_eq!(
+            c.key_response_max_bytes(),
+            DEFAULT_MAX_HEADER_BYTES * DEFAULT_KEY_RESPONSE_BODY_MULTIPLIER
+        );
+    }
+
+    #[test]
+    fn key_response_max_bytes_saturates_on_overflow() {
+        let c = WireConfig {
+            max_header_bytes: usize::MAX,
+            key_response_body_multiplier: 4,
+            ..Default::default()
+        };
+        // Saturating multiplication must not panic.
+        assert_eq!(c.key_response_max_bytes(), usize::MAX);
+    }
+
+    #[test]
+    fn config_roundtrips_through_json() {
+        let original = Config {
+            wire: WireConfig {
+                max_header_bytes: 16_384,
+                key_response_body_multiplier: 2,
+                header_read_initial_capacity: 1024,
+                response_read_chunk_bytes: 8192,
+            },
+            noise: NoiseConfig {
+                max_frame_payload: 8192,
+                handshake_scratch_bytes: 512,
+            },
+        };
+        let json = serde_json::to_string(&original).expect("serialise");
+        let back: Config = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn config_deserialises_from_partial_json() {
+        // Missing sub-tables and fields fall back to defaults because we
+        // use `#[serde(default)]` on Config.
+        let partial = r#"{"wire": {"max_header_bytes": 2048,
+            "key_response_body_multiplier": 4,
+            "header_read_initial_capacity": 512,
+            "response_read_chunk_bytes": 4096}}"#;
+        let c: Config = serde_json::from_str(partial).expect("partial config");
+        assert_eq!(c.wire.max_header_bytes, 2048);
+        assert_eq!(c.noise, NoiseConfig::default());
+    }
+
+    #[test]
+    fn config_rejects_unknown_fields() {
+        // Guards against silently-ignored typos in persisted configs.
+        let bad = r#"{"wire": {"max_header_bytes": 2048,
+            "key_response_body_multiplier": 4,
+            "header_read_initial_capacity": 512,
+            "response_read_chunk_bytes": 4096,
+            "unexpected": 1}}"#;
+        let result: Result<Config, _> = serde_json::from_str(bad);
+        assert!(result.is_err(), "unknown field must be rejected");
+    }
+}

--- a/crates/hamma-core/src/lib.rs
+++ b/crates/hamma-core/src/lib.rs
@@ -10,5 +10,8 @@
 
 #![deny(missing_docs)]
 
+pub mod config;
 pub mod keys;
 pub mod types;
+
+pub use config::Config;


### PR DESCRIPTION
## Summary

Agent-first parameterization pass on hamma, per #7. Every behavioral
tuning knob in `hamma-core` + `dictyon` moves from hard-coded `const`
to `hamma_core::config::Config` — serde-roundtrippable, non-exhaustive,
and documented with unit / range / symptom on every field so future
agents can query the parameter registry without source-diving.

### Constants parameterized (6 total)

- **Wire I/O limits (4):** `max_header_bytes`, `key_response_body_multiplier`
  (with derived `key_response_max_bytes`), `header_read_initial_capacity`,
  `response_read_chunk_bytes` — all live on `WireConfig`.
- **Noise framing (2):** `max_frame_payload`, `handshake_scratch_bytes` —
  on `NoiseConfig`.

### Constants deliberately NOT parameterized

Cryptographic invariants and wire-contract values remain `const` with a
header comment spelling out why:

- `NOISE_PARAMS = "Noise_IK_25519_ChaChaPoly_BLAKE2s"` — algorithm
  identifier; changing it is a handshake break.
- `TAG_LEN = 16` — Poly1305 authentication tag size.
- `KEY_LEN = 32` — Curve25519 key length.
- `PROTOCOL_VERSION = 1`, `MSG_TYPE_{INITIATION,RESPONSE,TRANSPORT}`,
  `FRAME_TYPE_TRANSPORT = 0x04` — Tailscale wire-format bytes.
- `UPGRADE_PATH = "/ts2021"`, `UPGRADE_HEADER = "tailscale-control-protocol"`,
  `KEY_PATH = "/key?v=71"` — HTTP wire contract.
- `MapRequest::version = 68` — protocol version speak, not a tuning knob.

### API stability

- `NoiseHandshake::new` / `NoiseTransport::from_snow` unchanged; new
  `with_config` / `from_snow_with_config` constructors expose the knobs.
- `ControlConfig` gains a `config: Config` field. Added
  `ControlConfig::new(url, key)` helper; existing callers
  (example, integration tests) migrated onto it.
- New free functions `fetch_server_key_with_config` and
  `fetch_server_key_with_tls_and_config`.

### Tests

- 6 new unit tests on `hamma_core::config` covering default values,
  serde round-trip, partial-JSON deserialisation, unknown-field rejection,
  and overflow safety on `key_response_max_bytes`.
- 1 new config-observable-behavior test on `dictyon::noise`: a
  tightened `max_frame_payload` rejects a payload the default accepts,
  proving the knob is wired, not just declared.

### Commit split

1. `feat(hamma-core): add Config struct`
2. `refactor(dictyon/noise): parameterize framing knobs`
3. `refactor(dictyon/wire): parameterize I/O limits`
4. `chore(lint): extend pub-visibility ignore to config module`

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --all` (68 tests, all pass)
- [x] `kanon lint . --summary` (no open violations)
- [x] `kanon gate` (all stages pass)

Closes #7