### PR TITLE
fix(ci): resolve cargo-deny + MSRV + binary smoke failures

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,19 +82,6 @@ jobs:
       - name: Build docs
         run: cargo doc --workspace --no-deps
 
-  # WHY: Binary builds and runs correctly with default features.
-  # Catches link errors and missing runtime deps.
-  smoke:
-    name: Binary smoke test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      # PROJECT: replace BINARY_CRATE and BINARY_NAME with your project's values
-      - name: Build binary
-        run: cargo build --release -p BINARY_CRATE
-      - name: Verify binary runs
-        run: ./target/release/BINARY_NAME --version || ./target/release/BINARY_NAME --help || true
+  # NOTE: No "Binary smoke test" job — hamma is a library-only workspace
+  # (dictyon + hamma-core, no [[bin]] targets). Reintroduce when a CLI/daemon
+  # crate is added, pinning BINARY_CRATE/BINARY_NAME to real values.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,30 +45,8 @@ disallowed_types = "deny"
 snafu = "0.8"
 
 # TLS
-rustls = {
-    version = "0.23",
-    default-features = false,
-    features = ["logging", "ring", "tls12"],
-}
 tokio-rustls = { version = "0.26", default-features = false }
 webpki-roots = "1"
-
-# Serialization
-serde = { version = "1", default-features = false, features = [
-    "derive",
-    "std",
-] }
-serde_json = { version = "1", default-features = false, features = ["std"] }
-
-# Async runtime
-tokio = { version = "1", default-features = false, features = [
-    "rt-multi-thread",
-    "macros",
-    "net",
-    "time",
-    "sync",
-    "io-util",
-] }
 
 # Tracing
 tracing = "0.1"
@@ -92,6 +70,36 @@ proptest = "1"
 
 # Local workspace crates
 hamma-core = { path = "crates/hamma-core", version = "0.1.0" }
+
+# Expanded forms (inline table exceeded 80 columns; MSRV 1.85 predates TOML 1.1
+# multi-line inline tables, so use [workspace.dependencies.X] blocks instead).
+
+[workspace.dependencies.rustls]
+version = "0.23"
+default-features = false
+features = ["logging", "ring", "tls12"]
+
+[workspace.dependencies.serde]
+version = "1"
+default-features = false
+features = ["derive", "std"]
+
+[workspace.dependencies.serde_json]
+version = "1"
+default-features = false
+features = ["std"]
+
+[workspace.dependencies.tokio]
+version = "1"
+default-features = false
+features = [
+    "rt-multi-thread",
+    "macros",
+    "net",
+    "time",
+    "sync",
+    "io-util",
+]
 
 [profile.dev.package."*"]
 opt-level = 2


### PR DESCRIPTION
## Summary

Three CI failures, two root causes. Both blocking PRs #11 and #12.

### Root cause 1 — `Cargo.toml` multi-line inline tables (breaks MSRV + cargo-deny)

Commit ea46514 (`fix: resolve 1 lint violations via local`, Qwen3.5-35B) rewrote
`rustls`, `serde`, `serde_json`, and `tokio` workspace dependencies as multi-line
inline tables to satisfy the `TOML/inline-table-too-long` kanon lint:

```toml
rustls = {
    version = "0.23",
    default-features = false,
    features = [...],
}
```

That syntax is TOML 1.1, supported by cargo only since Rust 1.94.0. hamma's
declared MSRV is 1.85, so the root manifest fails to parse under 1.85's toml
crate:

```
error: invalid inline table
expected `}`
  --> Cargo.toml:48:11
48 | rustls = {
   |           ^
```

This failure mode hit both the `MSRV (1.85)` job and the `cargo-deny` job (its
bundled parser is also pre-1.1), which is why two seemingly unrelated jobs
failed simultaneously.

`standards/TOML.md` already prescribes the correct fix: expanded
`[workspace.dependencies.X]` blocks when an inline table exceeds 80 columns
(lines 87-102), with the explicit note that multi-line inline tables must not
be used in repos whose MSRV predates 1.94 (lines 9-11). The local-model lint
fix violated the standard; this PR restores compliance by converting the four
offending entries to expanded-block form. Trailing newline on Cargo.toml also
restored (it had been dropped by the same auto-fix).

### Root cause 2 — unset smoke-test placeholders (breaks binary smoke test)

`.github/workflows/rust.yml` was generated from the forkwright template and
never customized — the `smoke` job still ran `cargo build --release -p
BINARY_CRATE` and `./target/release/BINARY_NAME`. cargo errored with
`package ID specification BINARY_CRATE did not match any packages`.

hamma is library-only (dictyon + hamma-core, no `[[bin]]` targets), so there
is no binary to smoke-test. The job has been removed with an in-place comment
explaining when it should be re-added (once a CLI or daemon crate lands,
pinning real names).

## Commits

- `3a00a58` fix(toml): expand multi-line inline tables to named blocks
- `895f8fb` fix(ci): remove broken binary smoke test job

## Gates (local, main-equivalent worktree)

- `rustup run 1.85.0 cargo check --workspace` — clean
- `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 61 tests run, 61 passed
- `kanon lint . --summary` — 0 open violations
- `kanon gate` — PASS

## Follow-up

After merge, PRs #11 and #12 should go green on rebase.