### PR TITLE
chore: milestone hygiene (em-dash sweep in source comments)

### DIFF
--- a/crates/dictyon/examples/connect.rs
+++ b/crates/dictyon/examples/connect.rs
@@ -108,7 +108,7 @@ async fn run() -> Result<(), ExampleError> {
     let auth_key = match std::env::var("TS_AUTHKEY") {
         Ok(value) => Some(value),
         Err(std::env::VarError::NotPresent) => {
-            warn!("TS_AUTHKEY not set — server will require interactive auth");
+            warn!("TS_AUTHKEY not set - server will require interactive auth");
             None
         }
         Err(e) => {

--- a/crates/dictyon/src/lib.rs
+++ b/crates/dictyon/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Dictyon
 //!
-//! *δίκτυον — a net, a cast net, a thing woven to catch.*
+//! *δίκτυον - a net, a cast net, a thing woven to catch.*
 //!
 //! Peer-side client for the hamma mesh networking stack. Speaks
 //! wire-compatible Tailscale control protocol to an upstream coordination

--- a/crates/dictyon/src/noise/tests.rs
+++ b/crates/dictyon/src/noise/tests.rs
@@ -318,7 +318,7 @@ fn process_response_rejects_truncated_frame() {
         .initiation_message()
         .expect("initiation should succeed");
 
-    // Only 2 bytes — shorter than the 3-byte minimum header
+    // Only 2 bytes - shorter than the 3-byte minimum header
     let truncated = vec![MSG_TYPE_RESPONSE, 0x00];
     let result = handshake.process_response(&truncated);
     assert!(result.is_err(), "truncated frame must be rejected");

--- a/crates/dictyon/tests/wire_integration.rs
+++ b/crates/dictyon/tests/wire_integration.rs
@@ -297,7 +297,7 @@ async fn connects_and_completes_noise_handshake() {
         let (tcp2, _) = listener.accept().await.expect("accept noise conn");
         let mut tls2 = acceptor.accept(tcp2).await.expect("tls accept noise conn");
         let _transport = handle_noise_upgrade(&mut tls2, &keys_clone).await;
-        // Handshake complete — test just verifies connect() returns Ok.
+        // Handshake complete - test just verifies connect() returns Ok.
     });
 
     let config = dictyon::wire::ControlConfig::new(
@@ -408,7 +408,7 @@ async fn register_returns_authorized_with_preauth_key() {
         .await
         .expect("connect should succeed");
 
-    // Need a ControlConnection to build a ControlClient — use the helper
+    // Need a ControlConnection to build a ControlClient - use the helper
     // pattern from control.rs tests.
     let (conn, ()) = make_dummy_transport();
     let mut client = dictyon::control::ControlClient::new(conn, machine_key, node_key, disco_key);
@@ -434,7 +434,7 @@ async fn connection_to_unreachable_host_returns_error() {
         MachinePrivate::generate(),
     );
 
-    // Use the default (webpki) TLS config — we expect a TCP connect failure
+    // Use the default (webpki) TLS config - we expect a TCP connect failure
     // before TLS is even attempted.
     let result = dictyon::wire::connect(&config).await;
     assert!(

--- a/crates/hamma-core/src/config.rs
+++ b/crates/hamma-core/src/config.rs
@@ -1,6 +1,6 @@
 //! Behavioral configuration for the hamma stack.
 //!
-//! Every field in [`Config`] is a **tuning knob** — a value that a reasonable
+//! Every field in [`Config`] is a **tuning knob** - a value that a reasonable
 //! operator (or an agent, via aletheia's parameter registry, forkwright/hamma#7)
 //! might want to change without recompiling. Values documented here match the
 //! current hard-coded defaults; changing the default here changes the default
@@ -80,7 +80,7 @@ pub const DEFAULT_HANDSHAKE_SCRATCH_BYTES: usize = 256;
 
 /// Tuning knobs for the wire layer (TCP/TLS/HTTP upgrade I/O).
 ///
-/// Applies to [`dictyon::wire`](../../dictyon/wire/index.html) — the module
+/// Applies to [`dictyon::wire`](../../dictyon/wire/index.html) - the module
 /// that owns raw socket I/O and the HTTP upgrade handshake.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -89,7 +89,7 @@ pub struct WireConfig {
     /// Maximum HTTP response header block we will buffer, in bytes.
     ///
     /// **Controls:** memory bound for header parsing; attacker-resilience.
-    /// **Range:** `[1024, 65_536]` — below 1 KiB breaks legitimate control
+    /// **Range:** `[1024, 65_536]` - below 1 KiB breaks legitimate control
     /// servers; above 64 KiB is wasted memory per connection.
     /// **Default:** 8 KiB. Raise if a control server sends very large
     /// header blocks (e.g. many cookies); lower to harden against abuse.
@@ -107,7 +107,7 @@ pub struct WireConfig {
     /// Initial capacity hint for the header-scan buffer, in bytes.
     ///
     /// **Controls:** number of allocations during header read on small
-    /// responses. Does not cap size — that is `max_header_bytes`.
+    /// responses. Does not cap size - that is `max_header_bytes`.
     /// **Range:** `[64, max_header_bytes]`.
     /// **Default:** 512.
     pub header_read_initial_capacity: usize,
@@ -160,10 +160,10 @@ pub struct NoiseConfig {
     ///
     /// **Controls:** largest single control-plane message that can be sent
     /// without caller-side chunking.
-    /// **Range:** `[256, 65_519]` — the wire format uses a `u16` length;
+    /// **Range:** `[256, 65_519]` - the wire format uses a `u16` length;
     /// the 16-byte Poly1305 tag is added on top, so the absolute ceiling is
     /// `u16::MAX - 16 = 65_519`.
-    /// **Default:** 4 KiB — matches the reference implementation and most
+    /// **Default:** 4 KiB - matches the reference implementation and most
     /// control-plane message sizes.
     pub max_frame_payload: usize,
 
@@ -173,7 +173,7 @@ pub struct NoiseConfig {
     /// `write_message`/`read_message`. Must be ≥ the largest handshake
     /// message (≤ 96 bytes for IK without payload).
     /// **Range:** `[128, 4096]`.
-    /// **Default:** 256 — leaves headroom for payload-bearing IK variants.
+    /// **Default:** 256 - leaves headroom for payload-bearing IK variants.
     pub handshake_scratch_bytes: usize,
 }
 
@@ -190,7 +190,7 @@ impl Default for NoiseConfig {
 // Top-level Config
 // ---------------------------------------------------------------------------
 
-/// Top-level hamma configuration — a flat, persistable snapshot of every
+/// Top-level hamma configuration - a flat, persistable snapshot of every
 /// behavioral tuning knob across the stack.
 ///
 /// Construct via [`Config::default`] and mutate individual fields, or load

--- a/crates/hamma-core/src/lib.rs
+++ b/crates/hamma-core/src/lib.rs
@@ -6,7 +6,7 @@
 //! identity types, ACL representations, protocol constants.
 //!
 //! This crate has no network I/O and minimal dependencies. It must compile
-//! fast and stay boring — types, not behavior.
+//! fast and stay boring - types, not behavior.
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
## Summary

- Replace em-dash (U+2014) with ASCII hyphen across 6 source files (config docs, lib headers, test/example comments)
- Surfaced during 2026-05-24 milestone QA audit; em-dashes in code comments are a recognized AI-indicator class per fleet policy
- Aligns with existing README/CLAUDE.md style which already uses double-space-hyphen (" - ") for inline parentheticals

## Scope

Safe-class hygiene only. Zero behavior change, zero public-API change, fmt clean.

| File | Count |
|---|---|
| `crates/hamma-core/src/config.rs` | 8 |
| `crates/dictyon/tests/wire_integration.rs` | 3 |
| `crates/hamma-core/src/lib.rs` | 1 |
| `crates/dictyon/src/lib.rs` | 1 |
| `crates/dictyon/examples/connect.rs` | 1 |
| `crates/dictyon/src/noise/tests.rs` | 1 |

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [ ] CI green (auto-merge on green)