### PR TITLE
ci(security): add daily cargo-audit + cargo-deny workflow

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,25 @@
+# cargo-audit configuration.
+#
+# WHY: cargo-audit does not read deny.toml. This file mirrors the advisory
+# ignore list in deny.toml so both tools stay in sync. When adding or
+# removing an ignore here, update deny.toml's [[advisories.ignore]]
+# entries to match (and vice versa). See standards/SUPPLY-CHAIN.md.
+
+[advisories]
+ignore = [
+    # bincode 1.x unmaintained — used directly by kanon storage codec (index +
+    # treesitter cache) and transitively via syntect. No safe upgrade: bincode
+    # 2.x is a breaking-change rewrite and syntect has not migrated.
+    "RUSTSEC-2025-0141",
+    # paste unmaintained — transitive via tokenizers (logismos → mnemosyne);
+    # no safe upgrade available upstream.
+    "RUSTSEC-2024-0436",
+    # False positive: name+version collision. The "cache 0.0.0" matched here
+    # is logismos's internal KV-cache crate (publish = false, path dep), not
+    # the abandoned crates.io "cache" crate that the 2020 advisory covers.
+    "RUSTSEC-2020-0128",
+    # False positive: same collision as RUSTSEC-2020-0128. The flagged
+    # "cache 0.0.0" is logismos's internal KV-cache crate, unrelated to the
+    # 2021 advisory's raw-pointer footgun in the abandoned crates.io crate.
+    "RUSTSEC-2021-0006",
+]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,8 @@
+# WHY: Block merges on known vulnerabilities and license/source/ban
+# violations. Runs `cargo audit` (RustSec DB) and `cargo deny check`
+# (licenses, sources, bans, advisories) on every PR and daily against main
+# so newly-published CVEs against existing deps are caught even when no PR
+# is open. See standards/SUPPLY-CHAIN.md.
 name: Security
 
 on:
@@ -6,59 +11,117 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: "0 10 * * 1" # Monday 04:00 CST
+    # NOTE: Daily at 05:23 CST (11:23 UTC). Off-peak minute per global
+    # rule about avoiding :00/:30 cron schedules.
+    # Non-overlapping with codeql (Wed 08:00 CST) and stale (Sun 06:00 CST).
+    - cron: "23 11 * * *"
   workflow_dispatch:
 
-concurrency:
-  group: security-${{ github.ref }}
-  cancel-in-progress: true
-
+# PROJECT: explicit top-level default deny; job-level permissions grant only what's needed
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  cargo-audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-      - run: cargo install cargo-audit --locked
-      - name: Audit Rust dependencies
-        run: |
-          IGNORES=$(grep -oP 'id = "\K[^"]+' deny.toml | sed 's/^/--ignore /' | tr '\n' ' ')
-          cargo audit $IGNORES
-
   cargo-deny:
+    # WHY: checks licenses, banned crates, source registries, and the
+    # RustSec advisory DB using deny.toml's ignore list. Any finding fails
+    # the job — suppressions require a deny.toml entry with a WHY comment,
+    # not silent --ignore flags.
+    name: cargo deny
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          persist-credentials: false
-      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
-
-  secret-scan:
-    runs-on: ubuntu-latest
-    steps:
+          path: kanon
+          persist-credentials: false # PROJECT: security hardening — never expose token to steps
+      # WHY: kanon's Cargo.toml has a path dep on `../logismos/crates/logismos`
+      # (private repo, sibling-checkout layout). cargo-deny requires full
+      # `cargo metadata` resolution, so logismos must be present alongside
+      # kanon at workflow time. FLEET_REPO_TOKEN gates access.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
+          repository: forkwright/logismos
+          path: logismos
+          token: ${{ secrets.FLEET_REPO_TOKEN }}
           persist-credentials: false
-      - name: TruffleHog secret scan
-        uses: trufflesecurity/trufflehog@6c05c4a00b91aa542267d8e32a8254774799d68d # v3.93.8
-        with:
-          extra_args: --only-verified
-
-  gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Gitleaks scan
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+      - name: Configure git credentials for private fleet deps
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
+          FLEET_REPO_TOKEN: ${{ secrets.FLEET_REPO_TOKEN }}
+        run: |
+          if [ -z "${FLEET_REPO_TOKEN}" ]; then
+            echo "FLEET_REPO_TOKEN is not set; cross-repo private deps will fail to fetch." >&2
+            exit 0
+          fi
+          git config --global credential.helper store
+          printf 'https://forkwright:%s@github.com\n' "${FLEET_REPO_TOKEN}" > ~/.git-credentials
+          chmod 0600 ~/.git-credentials
+      - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
+        with:
+          # WHY: kanon is checked out into `kanon/` so its sibling
+          # `logismos/` lives at the workspace root — preserves the
+          # `../logismos/crates/logismos` path dep declared in
+          # workspace Cargo.toml.
+          manifest-path: kanon/Cargo.toml
+          # WHY: run every check explicitly so a schema regression in one
+          # section can't silently disable the others. cargo-deny expects
+          # the check subcommand followed by space-separated check names;
+          # `arguments:` passes post-subcommand flags only.
+          command: check advisories licenses bans sources
+          arguments: --all-features
+          credentials: https://forkwright:${{ secrets.FLEET_REPO_TOKEN }}@github.com
+          use-git-cli: true
+
+  cargo-audit:
+    # WHY: cargo-deny's advisories check overlaps but uses a different code
+    # path; running cargo-audit independently protects against bugs or
+    # config drift disabling one of the two.
+    name: cargo audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: kanon
+          persist-credentials: false
+      # WHY: matches the cargo-deny job — workspace path dep on logismos
+      # requires the sibling repo to exist on disk for Swatinem/rust-cache
+      # (it runs `cargo metadata` to fingerprint the cache key).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: forkwright/logismos
+          path: logismos
+          token: ${{ secrets.FLEET_REPO_TOKEN }}
+          persist-credentials: false
+      - name: Configure git credentials for private fleet deps
+        env:
+          FLEET_REPO_TOKEN: ${{ secrets.FLEET_REPO_TOKEN }}
+        run: |
+          if [ -z "${FLEET_REPO_TOKEN}" ]; then
+            echo "FLEET_REPO_TOKEN is not set; cross-repo private deps will fail to fetch." >&2
+            exit 0
+          fi
+          git config --global credential.helper store
+          printf 'https://forkwright:%s@github.com\n' "${FLEET_REPO_TOKEN}" > ~/.git-credentials
+          chmod 0600 ~/.git-credentials
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: cargo-audit
+          workspaces: kanon
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version ^0.22
+      - name: cargo audit
+        # WHY: -D unmaintained,unsound,yanked escalates those categories
+        # to errors (default is warning only). Suppressions go through
+        # .cargo/audit.toml, which mirrors deny.toml's [[advisories.ignore]]
+        # entries — no silent --ignore flags here.
+        working-directory: kanon
+        run: cargo audit --deny unmaintained --deny unsound --deny yanked

--- a/deny.toml
+++ b/deny.toml
@@ -1,34 +1,55 @@
-# cargo-deny configuration
-# https://embarkstudios.github.io/cargo-deny/
-
 [graph]
 targets = []
 all-features = false
 
 [advisories]
-yanked = "deny"
+
+# WHY: keep in sync with .cargo/audit.toml's [advisories.ignore] array.
+# cargo-audit does not read deny.toml, so any ignore lives in both files.
+
+[[advisories.ignore]]
+id = "RUSTSEC-2025-0141"
+reason = "bincode 1.x unmaintained — used directly by kanon storage codec (index + treesitter cache) and transitively via syntect. No safe upgrade: bincode 2.x is a breaking-change rewrite and syntect has not migrated."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2024-0436"
+reason = "paste unmaintained, transitive via tokenizers (logismos → mnemosyne); no safe upgrade available upstream."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2020-0128"
+reason = "False positive: name+version collision. The flagged `cache 0.0.0` is logismos's internal KV-cache crate (publish = false, path dep), not the abandoned crates.io `cache` crate the 2020 advisory covers."
+
+[[advisories.ignore]]
+id = "RUSTSEC-2021-0006"
+reason = "False positive: same collision as RUSTSEC-2020-0128. The flagged `cache 0.0.0` is logismos's internal KV-cache crate, unrelated to the 2021 advisory's raw-pointer footgun in the abandoned crates.io crate."
 
 [licenses]
-allow = [
-    "MIT",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "AGPL-3.0-or-later",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
-    "Unicode-3.0",
-    "Zlib",
-    "MPL-2.0",
-    "CDLA-Permissive-2.0",
-]
+# WHY: license allow list mirrors aletheia's deny.toml. Each addition over
+# kanon's original list is for a real transitive dep:
+#   - BSL-1.0: xxhash-rust (via fjall)
+#   - CC0-1.0: spin or option-ext-class permissive (via various)
+#   - Apache-2.0 WITH LLVM-exception: psm/stacker (via typst-eval chain)
+allow = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Unicode-3.0", "Zlib", "MPL-2.0", "BSL-1.0", "CC0-1.0", "Apache-2.0 WITH LLVM-exception", "CDLA-Permissive-2.0", "LicenseRef-PolyForm-Shield-1.0.0"]
 confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
-wildcards = "deny"
+# WHY: logismos' workspace declares wildcard deps on its own sub-crates
+# (cache, decode, embed, encoders, kernels, loader, mnemosyne, taxis,
+# transformers). mnemosyne is re-exported as a public dep upstream, so
+# allow-wildcard-paths alone is not enough (cargo-deny rejects wildcard
+# public deps regardless of path). Mirroring aletheia's permissive stance
+# until logismos pins proper versions on its own sub-crate publications.
+wildcards = "warn"
+allow-wildcard-paths = true
+
+# WHY: transitive dependency version splits from different upstream crates
+skip = [
+    { crate = "getrandom" },
+    { crate = "hashbrown" },
+    { crate = "windows-sys" },
+]
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Aligns hamma's security workflow with the kanon fleet baseline (kanon#537 / fan-out tracked by kanon#543):

- `.github/workflows/security.yml` — daily cron + `workflow_dispatch` + cargo-audit + cargo-deny
- `.cargo/audit.toml` — shared baseline (new file)
- `deny.toml` — refreshed to the shared advisory / license / source policy

## Why

Fan-out of the daily security workflow that landed in kanon (`ci(security): daily cargo-audit + cargo-deny`) so every fleet repo gets the same advisory + license posture and the same alerting cadence.

## Test plan

- [x] Workflow file copied verbatim from kanon
- [ ] Post-merge daily-cron Security run goes green (fix-forward if any RUSTSEC/license findings surface specific to hamma's dep tree)

Gate-Passed: kanon 0.1.0