### PR TITLE
ci(security): strip kanon-specific sibling checkout from workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,44 +40,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          path: kanon
           persist-credentials: false # PROJECT: security hardening — never expose token to steps
-      # WHY: kanon's Cargo.toml has a path dep on `../logismos/crates/logismos`
-      # (private repo, sibling-checkout layout). cargo-deny requires full
-      # `cargo metadata` resolution, so logismos must be present alongside
-      # kanon at workflow time. FLEET_REPO_TOKEN gates access.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: forkwright/logismos
-          path: logismos
-          token: ${{ secrets.FLEET_REPO_TOKEN }}
-          persist-credentials: false
-      - name: Configure git credentials for private fleet deps
-        env:
-          FLEET_REPO_TOKEN: ${{ secrets.FLEET_REPO_TOKEN }}
-        run: |
-          if [ -z "${FLEET_REPO_TOKEN}" ]; then
-            echo "FLEET_REPO_TOKEN is not set; cross-repo private deps will fail to fetch." >&2
-            exit 0
-          fi
-          git config --global credential.helper store
-          printf 'https://forkwright:%s@github.com\n' "${FLEET_REPO_TOKEN}" > ~/.git-credentials
-          chmod 0600 ~/.git-credentials
       - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
         with:
-          # WHY: kanon is checked out into `kanon/` so its sibling
-          # `logismos/` lives at the workspace root — preserves the
-          # `../logismos/crates/logismos` path dep declared in
-          # workspace Cargo.toml.
-          manifest-path: kanon/Cargo.toml
           # WHY: run every check explicitly so a schema regression in one
           # section can't silently disable the others. cargo-deny expects
           # the check subcommand followed by space-separated check names;
           # `arguments:` passes post-subcommand flags only.
           command: check advisories licenses bans sources
           arguments: --all-features
-          credentials: https://forkwright:${{ secrets.FLEET_REPO_TOKEN }}@github.com
-          use-git-cli: true
 
   cargo-audit:
     # WHY: cargo-deny's advisories check overlaps but uses a different code
@@ -89,33 +60,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          path: kanon
           persist-credentials: false
-      # WHY: matches the cargo-deny job — workspace path dep on logismos
-      # requires the sibling repo to exist on disk for Swatinem/rust-cache
-      # (it runs `cargo metadata` to fingerprint the cache key).
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: forkwright/logismos
-          path: logismos
-          token: ${{ secrets.FLEET_REPO_TOKEN }}
-          persist-credentials: false
-      - name: Configure git credentials for private fleet deps
-        env:
-          FLEET_REPO_TOKEN: ${{ secrets.FLEET_REPO_TOKEN }}
-        run: |
-          if [ -z "${FLEET_REPO_TOKEN}" ]; then
-            echo "FLEET_REPO_TOKEN is not set; cross-repo private deps will fail to fetch." >&2
-            exit 0
-          fi
-          git config --global credential.helper store
-          printf 'https://forkwright:%s@github.com\n' "${FLEET_REPO_TOKEN}" > ~/.git-credentials
-          chmod 0600 ~/.git-credentials
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: cargo-audit
-          workspaces: kanon
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked --version ^0.22
       - name: cargo audit
@@ -123,5 +72,4 @@ jobs:
         # to errors (default is warning only). Suppressions go through
         # .cargo/audit.toml, which mirrors deny.toml's [[advisories.ignore]]
         # entries — no silent --ignore flags here.
-        working-directory: kanon
         run: cargo audit --deny unmaintained --deny unsound --deny yanked


### PR DESCRIPTION
## Why

PR #24 fan-out copied `security.yml` verbatim from kanon. The kanon version hardcodes a sibling checkout of `forkwright/logismos` (private repo path-dep) and uses `FLEET_REPO_TOKEN` to authenticate it. hamma has no such path-dep and no `FLEET_REPO_TOKEN` secret, so every Security run on `main` since #24 merged fails with:

```
##[error]Input required and not supplied: token
```

(see https://github.com/forkwright/hamma/actions/runs/26389824432)

## What

- Drop the second `actions/checkout` (the `forkwright/logismos` clone) from both jobs.
- Drop the `Configure git credentials for private fleet deps` step from both jobs.
- Drop `path: kanon`, `manifest-path: kanon/Cargo.toml`, `workspaces: kanon`, `working-directory: kanon`, `credentials:`, and `use-git-cli: true` so cargo-deny / cargo-audit run against the default checkout at the workspace root.

No changes to `.cargo/audit.toml` or `deny.toml`.

## Verification

- cargo-deny + cargo-audit will run on this PR; auto-merge will land it once they go green, and the next daily run on `main` should also be green.