### PR TITLE
fix(control): apply peer patch map deltas

### DIFF
--- a/crates/dictyon/src/control/mod.rs
+++ b/crates/dictyon/src/control/mod.rs
@@ -19,8 +19,8 @@
 
 use hamma_core::keys::{DiscoPrivate, MachinePrivate, NodePrivate};
 use hamma_core::types::{
-    AuthInfo, DerpMap, DnsConfig, Hostinfo, MapRequest, MapResponse, Node, RegisterRequest,
-    RegisterResponse,
+    AuthInfo, DerpMap, DnsConfig, Hostinfo, MapRequest, MapResponse, Node, PeerChange,
+    RegisterRequest, RegisterResponse,
 };
 use snafu::Snafu;
 
@@ -349,6 +349,8 @@ impl ControlClient {
     ///
     /// - `peers_changed`: each changed/added peer replaces the existing
     ///   entry with the same key, or is appended if new.
+    /// - `peers_changed_patch`: lightweight mutations are applied to known
+    ///   peers with matching node IDs.
     /// - `peers_removed`: peers with matching keys are removed.
     /// - `node`: updates the self node if present.
     /// - `dns_config` and `derp_map`: replace the previous values if
@@ -417,6 +419,12 @@ impl ControlClient {
                     netmap.peers.retain(|p| !removed_keys.contains(&p.key));
                 }
 
+                if let Some(changes) = resp.peers_changed_patch {
+                    for change in changes {
+                        apply_peer_change(&mut netmap.peers, change);
+                    }
+                }
+
                 if let Some(dns) = resp.dns_config {
                     netmap.dns_config = Some(dns);
                 }
@@ -459,6 +467,44 @@ impl ControlClient {
             hostname,
             go_version: "dictyon/0.1.0".to_string(),
         }
+    }
+}
+
+fn apply_peer_change(peers: &mut [Node], change: PeerChange) {
+    let Some(peer) = peers.iter_mut().find(|peer| peer.id == change.node_id) else {
+        return;
+    };
+
+    if let Some(region) = change.derp_region.filter(|region| *region > 0) {
+        peer.derp = Some(format!("127.3.3.40:{region}"));
+    }
+
+    if let Some(cap) = change.cap.filter(|cap| *cap > 0) {
+        peer.cap = Some(cap);
+    }
+
+    if let Some(endpoints) = change.endpoints.filter(|endpoints| !endpoints.is_empty()) {
+        peer.endpoints = Some(endpoints);
+    }
+
+    if let Some(key) = change.key {
+        peer.key = key;
+    }
+
+    if let Some(disco_key) = change.disco_key {
+        peer.disco_key = Some(disco_key);
+    }
+
+    if let Some(online) = change.online {
+        peer.online = Some(online);
+    }
+
+    if let Some(last_seen) = change.last_seen {
+        peer.last_seen = Some(last_seen);
+    }
+
+    if let Some(key_expiry) = change.key_expiry {
+        peer.key_expiry = Some(key_expiry);
     }
 }
 

--- a/crates/dictyon/src/control/tests.rs
+++ b/crates/dictyon/src/control/tests.rs
@@ -9,7 +9,7 @@
 )]
 
 use hamma_core::keys::{DiscoPrivate, MachinePrivate, NodePrivate};
-use hamma_core::types::{DnsConfig, DnsResolver, MapResponse, Node};
+use hamma_core::types::{DnsConfig, DnsResolver, MapResponse, Node, PeerChange};
 
 use super::*;
 
@@ -228,6 +228,109 @@ fn apply_map_response_removes_peers() {
     assert_eq!(client.peers().len(), 2);
     assert_eq!(client.peers()[0].key, "nodekey:peer1");
     assert_eq!(client.peers()[1].key, "nodekey:peer3");
+}
+
+#[test]
+fn apply_map_response_applies_peer_patch_to_known_peer() {
+    let mut client = paired_client();
+
+    let initial = MapResponse {
+        node: Some(sample_node(1, "nodekey:self", "self.ts.net.")),
+        peers: Some(vec![sample_node(2, "nodekey:peer1", "peer1.ts.net.")]),
+        peers_changed: None,
+        peers_changed_patch: None,
+        peers_removed: None,
+        dns_config: None,
+        derp_map: None,
+        keep_alive: None,
+    };
+    client.apply_map_response(initial);
+
+    let delta = MapResponse {
+        node: None,
+        peers: None,
+        peers_changed: None,
+        peers_changed_patch: Some(vec![PeerChange {
+            node_id: 2,
+            derp_region: Some(7),
+            cap: Some(69),
+            cap_map: None,
+            endpoints: Some(vec!["203.0.113.10:41641".to_string()]),
+            key: Some("nodekey:peer1-rotated".to_string()),
+            disco_key: Some("discokey:peer1".to_string()),
+            online: Some(true),
+            last_seen: Some("2026-05-25T12:00:00Z".to_string()),
+            key_expiry: Some("2026-06-25T12:00:00Z".to_string()),
+        }]),
+        peers_removed: None,
+        dns_config: None,
+        derp_map: None,
+        keep_alive: None,
+    };
+    client.apply_map_response(delta);
+
+    let peer = &client.peers()[0];
+    assert_eq!(peer.id, 2);
+    assert_eq!(peer.derp.as_deref(), Some("127.3.3.40:7"));
+    assert_eq!(peer.cap, Some(69));
+    assert_eq!(
+        peer.endpoints.as_deref(),
+        Some(["203.0.113.10:41641".to_string()].as_slice())
+    );
+    assert_eq!(peer.key, "nodekey:peer1-rotated");
+    assert_eq!(peer.disco_key.as_deref(), Some("discokey:peer1"));
+    assert_eq!(peer.online, Some(true));
+    assert_eq!(peer.last_seen.as_deref(), Some("2026-05-25T12:00:00Z"));
+    assert_eq!(peer.key_expiry.as_deref(), Some("2026-06-25T12:00:00Z"));
+}
+
+#[test]
+fn apply_map_response_ignores_peer_patch_for_unknown_peer() {
+    let mut client = paired_client();
+
+    let initial = MapResponse {
+        node: Some(sample_node(1, "nodekey:self", "self.ts.net.")),
+        peers: Some(vec![sample_node(2, "nodekey:peer1", "peer1.ts.net.")]),
+        peers_changed: None,
+        peers_changed_patch: None,
+        peers_removed: None,
+        dns_config: None,
+        derp_map: None,
+        keep_alive: None,
+    };
+    client.apply_map_response(initial);
+
+    let delta = MapResponse {
+        node: None,
+        peers: None,
+        peers_changed: None,
+        peers_changed_patch: Some(vec![PeerChange {
+            node_id: 99,
+            derp_region: Some(7),
+            cap: Some(69),
+            cap_map: None,
+            endpoints: Some(vec!["203.0.113.10:41641".to_string()]),
+            key: Some("nodekey:unknown".to_string()),
+            disco_key: Some("discokey:unknown".to_string()),
+            online: Some(true),
+            last_seen: Some("2026-05-25T12:00:00Z".to_string()),
+            key_expiry: Some("2026-06-25T12:00:00Z".to_string()),
+        }]),
+        peers_removed: None,
+        dns_config: None,
+        derp_map: None,
+        keep_alive: None,
+    };
+    client.apply_map_response(delta);
+
+    assert_eq!(client.peers().len(), 1);
+    let peer = &client.peers()[0];
+    assert_eq!(peer.id, 2);
+    assert_eq!(peer.key, "nodekey:peer1");
+    assert!(peer.derp.is_none());
+    assert!(peer.endpoints.is_none());
+    assert!(peer.disco_key.is_none());
+    assert!(peer.online.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- apply PeersChangedPatch entries to known peers by NodeID during map response delta handling
- update patchable peer fields already represented on Node, including DERP region, cap, endpoints, key, disco key, online state, last seen, and key expiry
- add unit coverage for known-peer patch application and unknown NodeID no-op behavior

## Scope
Progresses #20 by covering the live peer-state application slice after PR #32's parse-only type support. This does not close #20; zstd, numeric/object PeersRemoved compatibility, transport cleanup, tracing, and map-stream integration coverage remain open.

## Gates
- cargo fmt --all --check
- cargo check --workspace --all-targets
- cargo test --workspace
- git diff --check