### PR TITLE
fix(control): accept node id peer removals

### DIFF
--- a/crates/dictyon/src/control/mod.rs
+++ b/crates/dictyon/src/control/mod.rs
@@ -19,7 +19,7 @@
 
 use hamma_core::keys::{DiscoPrivate, MachinePrivate, NodePrivate};
 use hamma_core::types::{
-    AuthInfo, DerpMap, DnsConfig, Hostinfo, MapRequest, MapResponse, Node, PeerChange,
+    AuthInfo, DerpMap, DnsConfig, Hostinfo, MapRequest, MapResponse, Node, PeerChange, PeerRemoval,
     RegisterRequest, RegisterResponse,
 };
 use snafu::Snafu;
@@ -351,7 +351,7 @@ impl ControlClient {
     ///   entry with the same key, or is appended if new.
     /// - `peers_changed_patch`: lightweight mutations are applied to known
     ///   peers with matching node IDs.
-    /// - `peers_removed`: peers with matching keys are removed.
+    /// - `peers_removed`: peers with matching node IDs or keys are removed.
     /// - `node`: updates the self node if present.
     /// - `dns_config` and `derp_map`: replace the previous values if
     ///   present.
@@ -415,8 +415,10 @@ impl ControlClient {
                 }
 
                 // Peer removals.
-                if let Some(removed_keys) = resp.peers_removed {
-                    netmap.peers.retain(|p| !removed_keys.contains(&p.key));
+                if let Some(removals) = resp.peers_removed {
+                    netmap
+                        .peers
+                        .retain(|peer| !removals.iter().any(|removal| removes_peer(removal, peer)));
                 }
 
                 if let Some(changes) = resp.peers_changed_patch {
@@ -505,6 +507,13 @@ fn apply_peer_change(peers: &mut [Node], change: PeerChange) {
 
     if let Some(key_expiry) = change.key_expiry {
         peer.key_expiry = Some(key_expiry);
+    }
+}
+
+fn removes_peer(removal: &PeerRemoval, peer: &Node) -> bool {
+    match removal {
+        PeerRemoval::NodeId(node_id) => peer.id == *node_id,
+        PeerRemoval::NodeKey(key) => peer.key == *key,
     }
 }
 

--- a/crates/dictyon/src/control/tests.rs
+++ b/crates/dictyon/src/control/tests.rs
@@ -9,7 +9,7 @@
 )]
 
 use hamma_core::keys::{DiscoPrivate, MachinePrivate, NodePrivate};
-use hamma_core::types::{DnsConfig, DnsResolver, MapResponse, Node, PeerChange};
+use hamma_core::types::{DnsConfig, DnsResolver, MapResponse, Node, PeerChange, PeerRemoval};
 
 use super::*;
 
@@ -218,7 +218,7 @@ fn apply_map_response_removes_peers() {
         peers: None,
         peers_changed: None,
         peers_changed_patch: None,
-        peers_removed: Some(vec!["nodekey:peer2".to_string()]),
+        peers_removed: Some(vec![PeerRemoval::NodeKey("nodekey:peer2".to_string())]),
         dns_config: None,
         derp_map: None,
         keep_alive: None,
@@ -228,6 +228,43 @@ fn apply_map_response_removes_peers() {
     assert_eq!(client.peers().len(), 2);
     assert_eq!(client.peers()[0].key, "nodekey:peer1");
     assert_eq!(client.peers()[1].key, "nodekey:peer3");
+}
+
+#[test]
+fn apply_map_response_removes_peers_by_node_id() {
+    let mut client = paired_client();
+
+    let initial = MapResponse {
+        node: Some(sample_node(1, "nodekey:self", "self.ts.net.")),
+        peers: Some(vec![
+            sample_node(2, "nodekey:peer1", "peer1.ts.net."),
+            sample_node(3, "nodekey:peer2", "peer2.ts.net."),
+            sample_node(4, "nodekey:peer3", "peer3.ts.net."),
+        ]),
+        peers_changed: None,
+        peers_changed_patch: None,
+        peers_removed: None,
+        dns_config: None,
+        derp_map: None,
+        keep_alive: None,
+    };
+    client.apply_map_response(initial);
+
+    let delta = MapResponse {
+        node: None,
+        peers: None,
+        peers_changed: None,
+        peers_changed_patch: None,
+        peers_removed: Some(vec![PeerRemoval::NodeId(3)]),
+        dns_config: None,
+        derp_map: None,
+        keep_alive: None,
+    };
+    client.apply_map_response(delta);
+
+    assert_eq!(client.peers().len(), 2);
+    assert_eq!(client.peers()[0].id, 2);
+    assert_eq!(client.peers()[1].id, 4);
 }
 
 #[test]
@@ -499,8 +536,11 @@ proptest::proptest! {
 
         // Remove up to n_remove of the original peers.
         let n_to_remove = n_remove.min(n_initial);
-        let removed_keys: Vec<String> = (0..n_to_remove)
-            .map(|i| format!("nodekey:peer{i}"))
+        let removed_keys: Vec<String> = (0..n_to_remove).map(|i| format!("nodekey:peer{i}")).collect();
+        let removals: Vec<PeerRemoval> = removed_keys
+            .iter()
+            .cloned()
+            .map(PeerRemoval::NodeKey)
             .collect();
 
         if n_to_remove > 0 {
@@ -509,7 +549,7 @@ proptest::proptest! {
                 peers: None,
                 peers_changed: None,
                 peers_changed_patch: None,
-                peers_removed: Some(removed_keys.clone()),
+                peers_removed: Some(removals),
                 dns_config: None,
                 derp_map: None,
                 keep_alive: None,

--- a/crates/hamma-core/src/types.rs
+++ b/crates/hamma-core/src/types.rs
@@ -171,9 +171,9 @@ pub struct MapResponse {
     #[serde(rename = "PeersChangedPatch")]
     pub peers_changed_patch: Option<Vec<PeerChange>>,
 
-    /// Node key strings of peers that were removed.
+    /// Peers that were removed.
     #[serde(rename = "PeersRemoved")]
-    pub peers_removed: Option<Vec<String>>,
+    pub peers_removed: Option<Vec<PeerRemoval>>,
 
     /// DNS configuration for `MagicDNS` and split DNS.
     #[serde(rename = "DNSConfig")]
@@ -187,6 +187,42 @@ pub struct MapResponse {
     /// ignored.
     #[serde(rename = "KeepAlive")]
     pub keep_alive: Option<bool>,
+}
+
+/// Peer removal marker from [`MapResponse::peers_removed`].
+///
+/// Newer control servers identify removed peers by numeric node ID. The string
+/// variant preserves compatibility with older key-string frames.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(from = "PeerRemovalWire")]
+pub enum PeerRemoval {
+    /// Server-assigned numeric node identifier.
+    NodeId(i64),
+
+    /// Node public key string, serialized as `"nodekey:hex..."`.
+    NodeKey(String),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PeerRemovalWire {
+    NodeId(i64),
+    NodeKey(String),
+    NodeIdObject {
+        #[serde(rename = "NodeID")]
+        node_id: i64,
+    },
+}
+
+impl From<PeerRemovalWire> for PeerRemoval {
+    fn from(value: PeerRemovalWire) -> Self {
+        match value {
+            PeerRemovalWire::NodeId(node_id) | PeerRemovalWire::NodeIdObject { node_id } => {
+                Self::NodeId(node_id)
+            }
+            PeerRemovalWire::NodeKey(key) => Self::NodeKey(key),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -579,5 +615,27 @@ mod tests {
         assert_eq!(patch[0].key_expiry.as_deref(), Some("2026-11-01T00:00:00Z"));
         assert_eq!(patch[0].cap, Some(68));
         assert!(patch[0].cap_map.is_some());
+    }
+
+    #[test]
+    fn map_response_deserializes_peer_removals_by_node_id_and_key() {
+        let json = r#"{
+            "PeersRemoved": [
+                67890,
+                {"NodeID": 67891},
+                "nodekey:legacy"
+            ]
+        }"#;
+
+        let resp: MapResponse = serde_json::from_str(json).expect("removal frame should parse");
+        let removals = resp.peers_removed.expect("removals should be present");
+
+        assert_eq!(removals.len(), 3);
+        assert_eq!(removals[0], PeerRemoval::NodeId(67890));
+        assert_eq!(removals[1], PeerRemoval::NodeId(67891));
+        assert_eq!(
+            removals[2],
+            PeerRemoval::NodeKey("nodekey:legacy".to_string())
+        );
     }
 }

--- a/crates/hamma-core/tests/public_api.rs
+++ b/crates/hamma-core/tests/public_api.rs
@@ -16,7 +16,7 @@ use hamma_core::keys::{
 };
 use hamma_core::types::{
     AuthInfo, DerpMap, DnsConfig, DnsResolver, Hostinfo, MapRequest, MapResponse, Node, PeerChange,
-    RegisterRequest, RegisterResponse,
+    PeerRemoval, RegisterRequest, RegisterResponse,
 };
 
 #[test]
@@ -152,6 +152,20 @@ fn peer_change_patch_type_is_public_api() {
     );
     assert_eq!(change.online, Some(false));
     assert_eq!(change.cap, Some(68));
+}
+
+#[test]
+fn peer_removal_type_is_public_api() {
+    let json = r#"{"PeersRemoved":[7,{"NodeID":8},"nodekey:legacy"]}"#;
+    let resp: MapResponse = serde_json::from_str(json).expect("PeersRemoved parses");
+    let removals = resp.peers_removed.expect("removals present");
+
+    assert_eq!(removals[0], PeerRemoval::NodeId(7));
+    assert_eq!(removals[1], PeerRemoval::NodeId(8));
+    assert_eq!(
+        removals[2],
+        PeerRemoval::NodeKey("nodekey:legacy".to_string())
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse `MapResponse.PeersRemoved` entries as numeric node IDs, object-shaped `NodeID` removals, or legacy node key strings
- remove peers by numeric `Node.id` for upstream-compatible frames while preserving existing key-string removal behavior
- add core/public API parsing coverage and control-client application coverage

## Scope
Progresses #20 by covering the PeersRemoved compatibility slice after PR #33. This does not close #20; zstd, transport/wire cleanup, tracing, and map-stream integration coverage remain open.

## Gates
- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo test --workspace --all-targets
- git diff --check