### PR TITLE
feat(control): support zstd map responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -243,6 +245,7 @@ dependencies = [
  "tracing-subscriber",
  "webpki-roots",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]
@@ -437,6 +440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +556,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -1488,3 +1507,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ x25519-dalek = { version = "2", features = ["static_secrets"] }
 zeroize = { version = "1", features = ["derive"] }
 rand = "0.8"
 base64 = "0.22"
+zstd = "0.13"
 
 # Testing
 proptest = "1"

--- a/crates/dictyon/Cargo.toml
+++ b/crates/dictyon/Cargo.toml
@@ -21,6 +21,7 @@ hostname = { workspace = true }
 rustls = { workspace = true }
 tokio-rustls = { workspace = true }
 webpki-roots = { workspace = true }
+zstd = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/dictyon/src/control/mod.rs
+++ b/crates/dictyon/src/control/mod.rs
@@ -9,8 +9,8 @@
 //!
 //! Control plane messages are JSON, framed as `[4-byte LE size][payload]`.
 //! Payloads may be zstd-compressed (indicated by `Compress: "zstd"` in the
-//! request). This implementation handles uncompressed JSON; zstd support
-//! is deferred.
+//! request). Map response parsing accepts both compressed and uncompressed
+//! payloads.
 //!
 //! # References
 //!
@@ -293,6 +293,7 @@ impl ControlClient {
     pub fn build_map_request(&self) -> Result<Vec<u8>, ControlError> {
         let req = MapRequest {
             version: 68,
+            compress: Some("zstd".to_string()),
             node_key: self.node_key.public_key().to_hex(),
             disco_key: self.disco_key.public_key().to_hex(),
             endpoints: Vec::new(),
@@ -338,7 +339,8 @@ impl ControlClient {
                 ),
             })?;
 
-        let resp: MapResponse = serde_json::from_slice(payload)?;
+        let payload = decode_map_payload(payload)?;
+        let resp: MapResponse = serde_json::from_slice(&payload)?;
         Ok(resp)
     }
 
@@ -532,6 +534,22 @@ fn frame_message(payload: &[u8]) -> Vec<u8> {
     framed.extend_from_slice(&size.to_le_bytes());
     framed.extend_from_slice(payload);
     framed
+}
+
+fn decode_map_payload(payload: &[u8]) -> Result<std::borrow::Cow<'_, [u8]>, ControlError> {
+    if !is_zstd_frame(payload) {
+        return Ok(std::borrow::Cow::Borrowed(payload));
+    }
+
+    zstd::stream::decode_all(payload)
+        .map(std::borrow::Cow::Owned)
+        .map_err(|err| ControlError::MalformedResponse {
+            message: format!("zstd decode failed: {err}"),
+        })
+}
+
+fn is_zstd_frame(payload: &[u8]) -> bool {
+    matches!(payload.get(..4), Some([0x28, 0xb5, 0x2f, 0xfd]))
 }
 
 /// Deserialize a [`RegisterResponse`] from raw (decrypted) bytes.

--- a/crates/dictyon/src/control/tests.rs
+++ b/crates/dictyon/src/control/tests.rs
@@ -407,6 +407,22 @@ fn register_builds_correct_json() {
 }
 
 #[test]
+fn map_request_advertises_zstd_compression() {
+    let client = paired_client();
+    let payload = client
+        .build_map_request()
+        .expect("map request should serialize");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&payload).expect("payload should be valid JSON");
+
+    assert_eq!(json["Version"].as_u64(), Some(68));
+    assert_eq!(json["Stream"].as_bool(), Some(true));
+    assert_eq!(json["OmitPeers"].as_bool(), Some(false));
+    assert_eq!(json["Compress"].as_str(), Some("zstd"));
+}
+
+#[test]
 fn parse_map_response_extracts_json() {
     let json_body = br#"{"KeepAlive":true}"#;
     let size = u32::try_from(json_body.len()).expect("test payload fits u32");
@@ -414,6 +430,22 @@ fn parse_map_response_extracts_json() {
     let mut frame = Vec::new();
     frame.extend_from_slice(&size.to_le_bytes());
     frame.extend_from_slice(json_body);
+
+    let resp = ControlClient::parse_map_response(&frame).expect("parse should succeed");
+
+    assert_eq!(resp.keep_alive, Some(true));
+}
+
+#[test]
+fn parse_map_response_extracts_zstd_json() {
+    let json_body = br#"{"KeepAlive":true}"#;
+    let compressed =
+        zstd::stream::encode_all(&json_body[..], 0).expect("test payload should compress");
+    let size = u32::try_from(compressed.len()).expect("test payload fits u32");
+
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&size.to_le_bytes());
+    frame.extend_from_slice(&compressed);
 
     let resp = ControlClient::parse_map_response(&frame).expect("parse should succeed");
 

--- a/crates/hamma-core/src/types.rs
+++ b/crates/hamma-core/src/types.rs
@@ -114,6 +114,13 @@ pub struct MapRequest {
     #[serde(rename = "Version")]
     pub version: u64,
 
+    /// Optional response compression requested from the control server.
+    ///
+    /// Tailscale-compatible servers accept `"zstd"` to send each map response
+    /// payload as an independently compressed zstandard frame.
+    #[serde(rename = "Compress", skip_serializing_if = "Option::is_none")]
+    pub compress: Option<String>,
+
     /// This node's public key, serialized as `"nodekey:hex..."`. Public
     /// identifier, not a secret.
     #[serde(rename = "NodeKey")]

--- a/crates/hamma-core/tests/public_api.rs
+++ b/crates/hamma-core/tests/public_api.rs
@@ -59,6 +59,7 @@ fn machine_public_from_hex_rejects_wrong_length() {
 fn map_request_round_trips_through_json() {
     let req = MapRequest {
         version: 68,
+        compress: Some("zstd".to_string()),
         node_key: "nodekey:abc".to_string(),
         disco_key: "discokey:def".to_string(),
         endpoints: vec!["1.2.3.4:41641".to_string()],
@@ -74,6 +75,7 @@ fn map_request_round_trips_through_json() {
     let json = serde_json::to_string(&req).expect("MapRequest serializes");
     assert!(json.contains("\"NodeKey\":\"nodekey:abc\""));
     assert!(json.contains("\"Version\":68"));
+    assert!(json.contains("\"Compress\":\"zstd\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- advertise `Compress: "zstd"` on map requests
- decode zstd-compressed map response payloads before JSON parsing
- keep uncompressed map response parsing covered for compatibility

Refs #20.

## Verification
- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets`

Note: clippy reports the existing `PeerRemovalWire` enum variant naming warning from the current base, but exits successfully under the repository lint configuration.
