### PR TITLE
feat(control): instrument async control client entry points

### DIFF
--- a/crates/dictyon/src/control/mod.rs
+++ b/crates/dictyon/src/control/mod.rs
@@ -23,6 +23,7 @@ use hamma_core::types::{
     RegisterRequest, RegisterResponse,
 };
 use snafu::Snafu;
+use tracing::debug;
 
 use crate::transport::ControlConnection;
 use crate::wire::AsyncControlStream;
@@ -202,6 +203,11 @@ impl ControlClient {
         stream: &mut AsyncControlStream,
         auth_key: Option<&str>,
     ) -> Result<RegisterOutcome, ControlError> {
+        debug!(
+            target: "dictyon::control",
+            has_auth_key = auth_key.is_some(),
+            "sending register request",
+        );
         let payload = self.build_register_request(auth_key)?;
         let framed = frame_message(&payload);
         stream.send_message(&framed).await?;
@@ -210,8 +216,18 @@ impl ControlClient {
         let resp = parse_register_response(&raw)?;
 
         if let Some(url) = resp.auth_url.clone() {
+            debug!(
+                target: "dictyon::control",
+                outcome = "needs_auth",
+                "register requires interactive auth",
+            );
             Ok(RegisterOutcome::NeedsAuth { auth_url: url })
         } else {
+            debug!(
+                target: "dictyon::control",
+                outcome = "authorized",
+                "register authorized",
+            );
             Ok(RegisterOutcome::Authorized(resp))
         }
     }
@@ -229,6 +245,11 @@ impl ControlClient {
         stream: &mut AsyncControlStream,
         followup_url: &str,
     ) -> Result<RegisterResponse, ControlError> {
+        debug!(
+            target: "dictyon::control",
+            followup_url,
+            "polling registration followup",
+        );
         let req = RegisterRequest {
             node_key: self.node_key.public_key().to_hex(),
             old_node_key: String::new(), // kanon:ignore RUST/plain-string-secret -- public key hex, not a secret
@@ -257,6 +278,10 @@ impl ControlClient {
         &mut self,
         stream: &mut AsyncControlStream,
     ) -> Result<(), ControlError> {
+        debug!(
+            target: "dictyon::control",
+            "sending streaming map request",
+        );
         let payload = self.build_map_request()?;
         let framed = frame_message(&payload);
         stream.send_message(&framed).await?;
@@ -278,6 +303,11 @@ impl ControlClient {
         let raw = stream.recv_message().await?;
         let resp = Self::parse_map_response(&raw)?;
         let is_keepalive = resp.keep_alive == Some(true);
+        debug!(
+            target: "dictyon::control",
+            is_keepalive,
+            "received map update",
+        );
         self.apply_map_response(resp);
         Ok(is_keepalive)
     }


### PR DESCRIPTION
## Summary
- Add `tracing::debug!` events at the four async public entry points on `ControlClient` (`register`, `poll_registration`, `start_map_stream`, `recv_map_update`) under the `dictyon::control` target.
- First narrow slice of dictyon library tracing under #20. Does not touch transport/wire/noise instrumentation, which still need a deliberate span/event-scheme pass.

## Why
- `crates/dictyon/examples/connect.rs` already emits `tracing::info!`/`warn!` for the control flow, but no events fire from the library itself, so any consumer of `dictyon::control::ControlClient` has zero visibility into registration outcome, followup polling, map-stream initiation, or keepalive vs. non-keepalive map updates without re-wrapping every call site.
- Adding events at the four public async entry points gives that visibility without picking a span model that would constrain the larger transport/wire/noise tracing pass.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets`
- [x] `git diff --check`

Refs #20