### PR TITLE
chore(deps): remove unused direct deps from dictyon

### DIFF
--- a/crates/dictyon/Cargo.toml
+++ b/crates/dictyon/Cargo.toml
@@ -10,12 +10,10 @@ rust-version.workspace = true
 [dependencies]
 hamma-core = { workspace = true }
 snafu = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 snow = { workspace = true }
-zeroize = { workspace = true }
 base64 = { workspace = true }
 hostname = { workspace = true }
 rustls = { workspace = true }


### PR DESCRIPTION
cargo-machete identified `serde` and `zeroize` as unused direct dependencies in `crates/dictyon/Cargo.toml`.

- `serde`: dictyon uses `serde_json` directly (which brings in serde transitively) but never imports or calls the `serde` API itself
- `zeroize`: used by `hamma-core` and `x25519-dalek` transitively but not by dictyon directly

Both are kept in the workspace-level `[workspace.dependencies]` for use by other crates that need them.

Build and all tests verified passing after removal.