### PR TITLE
fix(lint): resolve clippy warnings in hamma-core and wire integration test

### DIFF
--- a/crates/dictyon/tests/wire_integration.rs
+++ b/crates/dictyon/tests/wire_integration.rs
@@ -84,10 +84,10 @@ async fn read_http_headers(
 /// Extract the value of an HTTP header from a raw header block.
 fn extract_header<'a>(headers: &'a str, name: &str) -> Option<&'a str> {
     for line in headers.lines() {
-        if let Some(rest) = line.strip_prefix(name) {
-            if let Some(value) = rest.strip_prefix(": ") {
-                return Some(value.trim());
-            }
+        if let Some(rest) = line.strip_prefix(name)
+            && let Some(value) = rest.strip_prefix(": ")
+        {
+            return Some(value.trim());
         }
     }
     None

--- a/crates/hamma-core/src/keys.rs
+++ b/crates/hamma-core/src/keys.rs
@@ -236,7 +236,7 @@ fn hex_encode(bytes: &[u8]) -> String {
 }
 
 fn hex_decode(s: &str) -> Result<Vec<u8>, KeyError> {
-    if s.len() % 2 != 0 {
+    if !s.len().is_multiple_of(2) {
         return Err(KeyError::InvalidHex {
             message: "odd number of hex digits".to_string(),
         });

--- a/crates/hamma-core/src/types.rs
+++ b/crates/hamma-core/src/types.rs
@@ -200,6 +200,9 @@ pub struct MapResponse {
 ///
 /// Newer control servers identify removed peers by numeric node ID. The string
 /// variant preserves compatibility with older key-string frames.
+// WHY: variant names match Tailscale control-protocol wire identifiers;
+// renaming would diverge from protocol documentation and break serde mappings.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(from = "PeerRemovalWire")]
 pub enum PeerRemoval {
@@ -210,6 +213,8 @@ pub enum PeerRemoval {
     NodeKey(String),
 }
 
+// WHY: variant names mirror the public PeerRemoval wire identifiers for serde symmetry.
+#[allow(clippy::enum_variant_names)]
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum PeerRemovalWire {


### PR DESCRIPTION
Fixes three clippy warnings that fire with `cargo clippy --all-targets --all-features`:

**keys.rs:239** (`manual_is_multiple_of`)
Replace `s.len() % 2 != 0` with `!s.len().is_multiple_of(2)`.

**types.rs** (`enum_variant_names` × 2)
`PeerRemoval` and `PeerRemovalWire` both have variants sharing the `Node` prefix. These are Tailscale control-protocol wire identifiers — renaming would diverge from protocol docs and break serde mappings. Suppressed with `#[allow(clippy::enum_variant_names)]` + WHY comment on each enum.

**wire_integration.rs:87** (`collapsible_if`)
Collapse nested `if let Some` blocks into a single `if let ... && let ...` expression.

Verified: zero clippy warnings, all tests passing, fmt clean.