### PR TITLE
ci(release): fix release-please config for Rust workspace root

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         id: release
         with:
           config-file: release-please-config.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
@@ -11,17 +11,54 @@
       "package-name": "hamma",
       "component": "hamma",
       "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
+        }
+      ],
       "changelog-sections": [
-        { "type": "feat", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "perf", "section": "Performance" },
-        { "type": "refactor", "section": "Refactoring" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "test", "hidden": true },
-        { "type": "chore", "hidden": true },
-        { "type": "ci", "hidden": true },
-        { "type": "style", "hidden": true },
-        { "type": "build", "hidden": true }
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance"
+        },
+        {
+          "type": "refactor",
+          "section": "Refactoring"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation"
+        },
+        {
+          "type": "test",
+          "hidden": true
+        },
+        {
+          "type": "chore",
+          "hidden": true
+        },
+        {
+          "type": "ci",
+          "hidden": true
+        },
+        {
+          "type": "style",
+          "hidden": true
+        },
+        {
+          "type": "build",
+          "hidden": true
+        }
       ]
     }
   }


### PR DESCRIPTION
Fixes the persistent release-please failure on main (`value at path package.version is not tagged`).

**Root cause**: `release-type: rust` expects `[package].version` at the configured path, but hamma uses `[workspace.package].version` (no root `[package]` section). This fires on every push to main.

**Fix**: Switch to `release-type: simple` with an `extra-files` jsonpath targeting `$.workspace.package.version` in `Cargo.toml`. This is the fleet-standard approach used by akroasis and other Rust workspace repos in forkwright.

**Also**: Bump `googleapis/release-please-action` from v4 SHA (Node 20, deprecated June 2026) to v5 SHA (Node 24).

Gate-Passed: gh-workflow-parse-only (workflow + JSON config only; no Rust changes)