### PR TITLE
chore(ci): add osv-scanner to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,3 +73,14 @@ jobs:
         # .cargo/audit.toml, which mirrors deny.toml's [[advisories.ignore]]
         # entries — no silent --ignore flags here.
         run: cargo audit --deny unmaintained --deny unsound --deny yanked
+
+  osv-scanner:
+    name: osv-scanner
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2
+    with:
+      scan-args: |-
+        --lockfile=./Cargo.lock
+        --config=./osv-scanner.toml
+    permissions:
+      security-events: write
+      contents: read

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,4 @@
+# OSV-Scanner advisory waiver list.
+# Entries must mirror .cargo/audit.toml [[advisories.ignore]] and deny.toml
+# [[advisories.ignore]] so all three scanners agree. Add entries with a
+# WHY comment and the date added.


### PR DESCRIPTION
Adds OSV-Scanner using Google's reusable workflow to the security pipeline, scanning `Cargo.lock` with config in `osv-scanner.toml`.

Refs: kanon#508